### PR TITLE
fix: getFileFromClsi

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -421,6 +421,7 @@ export class BaseAPI {
 
     async getFileFromClsi(identity:Identity, url:string, compileGroup:string) {
         let content: Buffer[] = [];
+        url = url.replace(/^\/+/g, '');
         while(true) {
             const res = await fetch(this.url+url, {
                 method: 'GET', redirect: 'manual', agent: this.agent,


### PR DESCRIPTION
It seems when acquire the compiled result, the url will have double "//" which somtime cause a 404.
![2023-09-04 16-45-00 的屏幕截图](https://github.com/iamhyc/Overleaf-Workshop/assets/51881852/4463cdf9-c3cf-4e03-8af7-d73e099df9e3)
