### PR TITLE
update reverse sync

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -447,18 +447,20 @@ export class BaseAPI {
     }
 
     async proxySyncPdf(identity:Identity, projectId:string, page:number, h:number, v:number) {
-        const res = await fetch(this.url+`project/${projectId}/sync/pdf?page=${page}&h=${h}&v=${v}`, {
+        const res = await fetch(this.url+`project/${projectId}/sync/pdf?page=${page}&h=${h.toFixed(2)}&v=${v.toFixed(2)}`, {
             method: 'GET', redirect: 'manual', agent: this.agent,
             headers: {
                 'Connection': 'keep-alive',
+                'Content-Type': 'application/json',
                 'Cookie': identity.cookies.split(';')[0],
+                'X-Csrf-Token': identity.csrfToken,
             }
         });
 
         if (res.status===200) {
             return {
                 type: 'success',
-                syncPdf: (await res.json() as any).code as SyncPdfResponseSchema
+                syncPdf: (await res.json() as any).code[0] as SyncPdfResponseSchema
             };
         } else {
             return {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('compileManager.syncCode', () => {
         compileManager.syncCode();
     }));
-    context.subscriptions.push(vscode.commands.registerCommand('compileManager.syncPdf', (page,h,v) => {
-        compileManager.syncPdf(page,h,v);
+    context.subscriptions.push(vscode.commands.registerCommand('compileManager.syncPdf', (r) => {
+        compileManager.syncPdf(r);
     }));
 }


### PR DESCRIPTION
This requests mainly contains the impementation of _translation_ from mouse click position to PDF point.
In `src/api/base.ts`, the additional tokern is added when call for update to Overleaf server.
In  `src/extension.ts`, introduce some data type translation.
In `views/vscode-pdf-viewer.js`, the main _translation_ function is implemented.
in `src/utils/compileManager.ts`, the reverse sync followed https://github.com/iamhyc/Overleaf-Workshop/pull/9#discussion_r1319470002 is added. However, simply selection seems to not able to jump to tex location, additional reveal Range is added. Besides, it seems selection api will select line number + 1 rather than line number, the input line number of api is minused 1 here.
