### PR TITLE
handle out-of-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.2.3",
       "hasInstallScript": true,
       "dependencies": {
+        "@types/diff-match-patch": "^1.0.34",
         "diff": "^5.1.0",
+        "diff-match-patch": "^1.0.5",
         "form-data": "^4.0.0",
         "mime-types": "^2.1.35",
         "node-fetch": "^2.6.13",
@@ -184,6 +186,11 @@
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.3.tgz",
       "integrity": "sha512-amrLbRqTU9bXMCc6uX0sWpxsQzRIo9z6MJPkH1pkez/qOxuqSZVuryJAWoBRq94CeG8JxY+VK4Le9HtjQR5T9A==",
       "dev": true
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.34.tgz",
+      "integrity": "sha512-GPT65LkqMpttT0BrYBzSv4FYgiEh7TXYxxFW8ufxn3+d6PhEJKdD4OAS4s0n8reeEku1ki56J2zj5FIPi5unVQ=="
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -1183,6 +1190,11 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -4268,6 +4280,11 @@
       "integrity": "sha512-amrLbRqTU9bXMCc6uX0sWpxsQzRIo9z6MJPkH1pkez/qOxuqSZVuryJAWoBRq94CeG8JxY+VK4Le9HtjQR5T9A==",
       "dev": true
     },
+    "@types/diff-match-patch": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.34.tgz",
+      "integrity": "sha512-GPT65LkqMpttT0BrYBzSv4FYgiEh7TXYxxFW8ufxn3+d6PhEJKdD4OAS4s0n8reeEku1ki56J2zj5FIPi5unVQ=="
+    },
     "@types/glob": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
@@ -4979,6 +4996,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -377,6 +377,8 @@
   },
   "dependencies": {
     "diff": "^5.1.0",
+    "diff-match-patch": "^1.0.5",
+    "@types/diff-match-patch": "^1.0.34",
     "form-data": "^4.0.0",
     "mime-types": "^2.1.35",
     "node-fetch": "^2.6.13",


### PR DESCRIPTION
Modify `remoteFileSystemProvider`  with out-of-sync handle.
When the updating version do not match the cache version, apply an immediate reload.

PS. When the overleaf website user modify the file content, the local cache update, which will not immedatelly apply to the vscode if there exist some modification of same position by vscode users (which is not compiled, that is the update is not sent to remote).  Thus when generating the following update, the remote update will be erased by comparing the local cache and current wriiten file.