### PR TITLE
fix: clientAgent multiple register

### DIFF
--- a/src/api/socketio.ts
+++ b/src/api/socketio.ts
@@ -37,7 +37,7 @@ export interface EventsHandler {
 }
 
 export class SocketIOAPI {
-    private _handlers: EventsHandler = {};
+    private _handlers: Array<EventsHandler> = [];
 
     private url: string;
     private socket?: any;
@@ -83,12 +83,15 @@ export class SocketIOAPI {
         return this._handlers;
     }
 
-    resumeEventHandlers(handlers: EventsHandler) {
-        this.updateEventHandlers(handlers);
+    resumeEventHandlers(handlers: Array<EventsHandler>) {
+        this._handlers = [];
+        handlers.forEach((handler) => {
+            this.updateEventHandlers(handler);
+        });
     }
 
     updateEventHandlers(handlers: EventsHandler) {
-        Object.assign(this._handlers, handlers);
+        this._handlers.push(handlers);
         Object.values(handlers).forEach((handler) => {
             switch (handler) {
                 case handlers.onFileCreated:


### PR DESCRIPTION
**PR Content**:  Fix the client agent multiple register problem as #23 mentioned.
**File Modification**:
+ In `src/api/socketio.ts`, using an stored array to resume handlers in same case will not overwritten after resume.
+ In `src/collaboration/clientManager.ts`, add disconnecting indicator.
+ In `src/provider/remoteFileSystemProvider.ts`,   instead of re-applying the init function which register clientAgent once more, a partial init is applied.