### PR TITLE
Code format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.5.4",
       "hasInstallScript": true,
       "dependencies": {
+        "@unified-latex/unified-latex-prettier": "^2.4.2",
+        "@unified-latex/unified-latex-util-parse": "^1.4.2",
         "diff-match-patch": "^1.0.5",
         "form-data": "^4.0.0",
         "mime-types": "^2.1.35",
         "minimatch": "^9.0.3",
         "node-fetch": "^2.6.13",
+        "prettier": "^3.1.1",
         "socket.io-client": "github:overleaf/socket.io-client#0.9.17-overleaf-5",
         "uuid": "^9.0.1"
       },
@@ -264,6 +267,11 @@
       "integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag==",
       "dev": true
     },
+    "node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
@@ -464,6 +472,244 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@unified-latex/unified-latex-builder": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-builder/-/unified-latex-builder-1.4.2.tgz",
+      "integrity": "sha512-XVJJiMPiUOus/ZHtdsK9RADVsihUswSjI7IT+UAufIrJdQiLq5WlPI5pq26/T9HuPlZll3Dm4pWo9dmh15a3KQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-ctan": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-ctan/-/unified-latex-ctan-1.4.2.tgz",
+      "integrity": "sha512-jJ4mVjt0mEhMx98uYKRfVh2VqMuF43mvFD0GSysTgZb31+GE4OvPSpjjTjVtrmVmWfXIeqtc6RyDpRGKCmenyQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-builder": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-argspec": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-comments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-replace": "^1.4.2",
+        "@unified-latex/unified-latex-util-scan": "^1.4.2",
+        "@unified-latex/unified-latex-util-split": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "color": "^4.2.3"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-prettier": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-prettier/-/unified-latex-prettier-2.4.2.tgz",
+      "integrity": "sha512-gMvlKGiGi9zOWVHXPhzeURhPYwPIJ7MBht42et/sVb4Z2wTjhcn+bU7kookT067ywOptVZNBgJw+iAgSORAd+w==",
+      "dependencies": {
+        "@unified-latex/unified-latex-ctan": "^1.4.1",
+        "@unified-latex/unified-latex-types": "^1.3.1",
+        "@unified-latex/unified-latex-util-align": "^1.4.0",
+        "@unified-latex/unified-latex-util-match": "^1.4.0",
+        "@unified-latex/unified-latex-util-parse": "^1.4.1",
+        "@unified-latex/unified-latex-util-pgfkeys": "^1.4.0",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.0",
+        "@unified-latex/unified-latex-util-trim": "^1.4.0",
+        "@unified-latex/unified-latex-util-visit": "^1.4.0",
+        "prettier": "^3.0.3",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-types/-/unified-latex-types-1.4.2.tgz",
+      "integrity": "sha512-aSUMXpdf2UOuCld9P6Ll3IRw7LcE3K0vvlJa2KVpUS1mJA7UDBJ5OOChwFKiPzl/I4NKWJq0LOIsb+54a5Vo5w=="
+    },
+    "node_modules/@unified-latex/unified-latex-util-align": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-align/-/unified-latex-util-align-1.4.2.tgz",
+      "integrity": "sha512-JJGXaz0GLnYYaMNCafRydWbBl9ZEnKaUubUtUH//K2g9RSg/bHigP1Yo47u7g3fJSuNOFxMiNlZISmU+BnrmMA==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-argspec": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-argspec/-/unified-latex-util-argspec-1.4.2.tgz",
+      "integrity": "sha512-u8lu0awTJ6o1a0xZOpIV3RXqlNuy3HyGb17BHEjRIzOLIyqgF5LsVH4OX4MwK5Kjh9GySUE+mDMNqO2b1czIfQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-arguments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-arguments/-/unified-latex-util-arguments-1.4.2.tgz",
+      "integrity": "sha512-u0yocEmQc8Nbjg0CvUhmfsOPPiXQjHwquPiEMvWqxEV31KGty7jDCq+vDs7rALvMCrgkOR0ugeNtfjAsKa11HA==",
+      "dependencies": {
+        "@unified-latex/unified-latex-builder": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-argspec": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-scan": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-catcode": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-catcode/-/unified-latex-util-catcode-1.4.2.tgz",
+      "integrity": "sha512-05CooHT89eXBKjdUUO4KdOunRyfm1fb+ZyRgjD1kaJ3qxAF64KiyFapCgLPFDL98OyDjRYdELoU2GPzEHiP2xA==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-comments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-comments/-/unified-latex-util-comments-1.4.2.tgz",
+      "integrity": "sha512-90bbeaSZmgK9ueRno7fH25FNFmnkesLkIJtWjbBasdhMQWjI9jQtM3sgjDjMBHjFaNJSAiwm5cphGt4HhLy1BA==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-replace": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-environments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-environments/-/unified-latex-util-environments-1.4.2.tgz",
+      "integrity": "sha512-Mcv+C3Lr0+jx0DKGJOnIPXkhVHPmX+mr1+IO97ZWCC6ibmT8BdkQ0CCN1lUg0pEtEC+JU7KzcoEBkMyS7ftEvQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-match": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-match/-/unified-latex-util-match-1.4.2.tgz",
+      "integrity": "sha512-LEa1zE/hrZrUyGuA94AjTWN9/dIqGCdu/ETCT0eCD8jZmRTQPRnn/uKUEIXWTn5yvF6USYzM9Dx5w4pHaTUWaQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-parse/-/unified-latex-util-parse-1.4.2.tgz",
+      "integrity": "sha512-tTCIFnxfqS4xmPS/EENaEwjtf4ECiOSXStOm9MCt9EANgpxLR9qteLgagC5u7sFzvN6NHYYZDhe4XhcyRTvuRg==",
+      "dependencies": {
+        "@unified-latex/unified-latex-ctan": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-catcode": "^1.4.2",
+        "@unified-latex/unified-latex-util-environments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-pegjs": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pegjs/-/unified-latex-util-pegjs-1.4.2.tgz",
+      "integrity": "sha512-y0WSOpXRXx64dJ9mMLTe44ZzgRy+axNaZ6R0QgX6hc3IDnQph+gUZJG3sXgZCqZZBVV0/RGJOq9f804PZ9hKAg==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-pgfkeys": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pgfkeys/-/unified-latex-util-pgfkeys-1.4.2.tgz",
+      "integrity": "sha512-+iu/HRxqfWMUlr/F4oN2YbA+nwERbhDJXCknsDWBtNUw2dxX35Vu0Ldq9wuTKdJA+q0Lw2xakfZ58lVPgtXVIw==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-print-raw": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-print-raw/-/unified-latex-util-print-raw-1.4.2.tgz",
+      "integrity": "sha512-vOY48R72bEQDIIvW21gjFs+y/F+61UIq0UXUBnf4eyR7SWlQwuWt+rO1FTuT0faZJKXRZymB8c1oOLGQl+gWRQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-render-info": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-render-info/-/unified-latex-util-render-info-1.4.2.tgz",
+      "integrity": "sha512-b5vZqpgo3yyH3zDww3PRUDp8DiDEampBRZ3xX7nXbG/B26s4fydToDbMHP5Q9r5YD/hsjGEgHZzGeb96kV997w==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-replace": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-replace/-/unified-latex-util-replace-1.4.2.tgz",
+      "integrity": "sha512-kUdd/M9guhSCQk485BIO7ysIeEENkq3wixVNPEViC1hxR5GjSXnPIqEX0IWTE3uwcPZzskuTiccYG+z46ELULg==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-split": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-scan": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-scan/-/unified-latex-util-scan-1.4.2.tgz",
+      "integrity": "sha512-veoarQeQVW1A/oSRCH7RI7qz410MecmT1NjzptNz982ODxWT9SS42QSraxm80R4bVooMxjv8r2P5ShlH5u7uWQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "trie-prefix-tree": "^1.5.1"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-split": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-split/-/unified-latex-util-split-1.4.2.tgz",
+      "integrity": "sha512-IQpUheQpd+jE3fjbzsubhySL80hSRlxix/23/b5h4hwEeBOWU2epAnKG9pcWjvd7xefIH4cvtPvcuqnzry8kcQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-trim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-trim/-/unified-latex-util-trim-1.4.2.tgz",
+      "integrity": "sha512-uAxX03qGnCD+e3jtX3wcjDPvD0amGQeIwCsvBQ1ONhODInq+aBMxf6t1UGC2LpPCmJqAaLevP0pSR39Fzw8zLA==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "node_modules/@unified-latex/unified-latex-util-visit": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-visit/-/unified-latex-util-visit-1.4.2.tgz",
+      "integrity": "sha512-rGqiqiQsyywAZC6rBGteJYE0nSDw/AGddwZWB/KgWvN6VYXZEY8UeBQjcqf01CmaRC8hDXjYk6Pw+By5XfQ4fQ==",
+      "dependencies": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
@@ -616,6 +862,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -884,11 +1139,22 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -899,8 +1165,16 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1538,6 +1812,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2119,6 +2398,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {
@@ -3181,6 +3482,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3549,6 +3864,19 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3836,6 +4164,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/trie-prefix-tree": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/trie-prefix-tree/-/trie-prefix-tree-1.5.1.tgz",
+      "integrity": "sha512-Jjvj/dA97wXnabG/NLJUgo4IQMj6vucH+Qxm7of/omfWSmZlPqdRU6Ta4GmQqCZH+n3/iYZUwfvUoEhB0Hs83Q=="
+    },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -3864,6 +4197,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {
@@ -3951,6 +4293,47 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -4016,6 +4399,34 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/webidl-conversions": {
@@ -4372,6 +4783,11 @@
       "integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag==",
       "dev": true
     },
+    "@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
     "@types/uuid": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
@@ -4481,6 +4897,244 @@
       "requires": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@unified-latex/unified-latex-builder": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-builder/-/unified-latex-builder-1.4.2.tgz",
+      "integrity": "sha512-XVJJiMPiUOus/ZHtdsK9RADVsihUswSjI7IT+UAufIrJdQiLq5WlPI5pq26/T9HuPlZll3Dm4pWo9dmh15a3KQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-ctan": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-ctan/-/unified-latex-ctan-1.4.2.tgz",
+      "integrity": "sha512-jJ4mVjt0mEhMx98uYKRfVh2VqMuF43mvFD0GSysTgZb31+GE4OvPSpjjTjVtrmVmWfXIeqtc6RyDpRGKCmenyQ==",
+      "requires": {
+        "@unified-latex/unified-latex-builder": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-argspec": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-comments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-replace": "^1.4.2",
+        "@unified-latex/unified-latex-util-scan": "^1.4.2",
+        "@unified-latex/unified-latex-util-split": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "color": "^4.2.3"
+      }
+    },
+    "@unified-latex/unified-latex-prettier": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-prettier/-/unified-latex-prettier-2.4.2.tgz",
+      "integrity": "sha512-gMvlKGiGi9zOWVHXPhzeURhPYwPIJ7MBht42et/sVb4Z2wTjhcn+bU7kookT067ywOptVZNBgJw+iAgSORAd+w==",
+      "requires": {
+        "@unified-latex/unified-latex-ctan": "^1.4.1",
+        "@unified-latex/unified-latex-types": "^1.3.1",
+        "@unified-latex/unified-latex-util-align": "^1.4.0",
+        "@unified-latex/unified-latex-util-match": "^1.4.0",
+        "@unified-latex/unified-latex-util-parse": "^1.4.1",
+        "@unified-latex/unified-latex-util-pgfkeys": "^1.4.0",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.0",
+        "@unified-latex/unified-latex-util-trim": "^1.4.0",
+        "@unified-latex/unified-latex-util-visit": "^1.4.0",
+        "prettier": "^3.0.3",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-types/-/unified-latex-types-1.4.2.tgz",
+      "integrity": "sha512-aSUMXpdf2UOuCld9P6Ll3IRw7LcE3K0vvlJa2KVpUS1mJA7UDBJ5OOChwFKiPzl/I4NKWJq0LOIsb+54a5Vo5w=="
+    },
+    "@unified-latex/unified-latex-util-align": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-align/-/unified-latex-util-align-1.4.2.tgz",
+      "integrity": "sha512-JJGXaz0GLnYYaMNCafRydWbBl9ZEnKaUubUtUH//K2g9RSg/bHigP1Yo47u7g3fJSuNOFxMiNlZISmU+BnrmMA==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-argspec": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-argspec/-/unified-latex-util-argspec-1.4.2.tgz",
+      "integrity": "sha512-u8lu0awTJ6o1a0xZOpIV3RXqlNuy3HyGb17BHEjRIzOLIyqgF5LsVH4OX4MwK5Kjh9GySUE+mDMNqO2b1czIfQ==",
+      "requires": {
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-arguments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-arguments/-/unified-latex-util-arguments-1.4.2.tgz",
+      "integrity": "sha512-u0yocEmQc8Nbjg0CvUhmfsOPPiXQjHwquPiEMvWqxEV31KGty7jDCq+vDs7rALvMCrgkOR0ugeNtfjAsKa11HA==",
+      "requires": {
+        "@unified-latex/unified-latex-builder": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-argspec": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-scan": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-catcode": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-catcode/-/unified-latex-util-catcode-1.4.2.tgz",
+      "integrity": "sha512-05CooHT89eXBKjdUUO4KdOunRyfm1fb+ZyRgjD1kaJ3qxAF64KiyFapCgLPFDL98OyDjRYdELoU2GPzEHiP2xA==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-comments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-comments/-/unified-latex-util-comments-1.4.2.tgz",
+      "integrity": "sha512-90bbeaSZmgK9ueRno7fH25FNFmnkesLkIJtWjbBasdhMQWjI9jQtM3sgjDjMBHjFaNJSAiwm5cphGt4HhLy1BA==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-replace": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-environments": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-environments/-/unified-latex-util-environments-1.4.2.tgz",
+      "integrity": "sha512-Mcv+C3Lr0+jx0DKGJOnIPXkhVHPmX+mr1+IO97ZWCC6ibmT8BdkQ0CCN1lUg0pEtEC+JU7KzcoEBkMyS7ftEvQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-match": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-match/-/unified-latex-util-match-1.4.2.tgz",
+      "integrity": "sha512-LEa1zE/hrZrUyGuA94AjTWN9/dIqGCdu/ETCT0eCD8jZmRTQPRnn/uKUEIXWTn5yvF6USYzM9Dx5w4pHaTUWaQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-parse/-/unified-latex-util-parse-1.4.2.tgz",
+      "integrity": "sha512-tTCIFnxfqS4xmPS/EENaEwjtf4ECiOSXStOm9MCt9EANgpxLR9qteLgagC5u7sFzvN6NHYYZDhe4XhcyRTvuRg==",
+      "requires": {
+        "@unified-latex/unified-latex-ctan": "^1.4.2",
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-arguments": "^1.4.2",
+        "@unified-latex/unified-latex-util-catcode": "^1.4.2",
+        "@unified-latex/unified-latex-util-environments": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-pegjs": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pegjs/-/unified-latex-util-pegjs-1.4.2.tgz",
+      "integrity": "sha512-y0WSOpXRXx64dJ9mMLTe44ZzgRy+axNaZ6R0QgX6hc3IDnQph+gUZJG3sXgZCqZZBVV0/RGJOq9f804PZ9hKAg==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-pgfkeys": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-pgfkeys/-/unified-latex-util-pgfkeys-1.4.2.tgz",
+      "integrity": "sha512-+iu/HRxqfWMUlr/F4oN2YbA+nwERbhDJXCknsDWBtNUw2dxX35Vu0Ldq9wuTKdJA+q0Lw2xakfZ58lVPgtXVIw==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-pegjs": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-print-raw": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-print-raw/-/unified-latex-util-print-raw-1.4.2.tgz",
+      "integrity": "sha512-vOY48R72bEQDIIvW21gjFs+y/F+61UIq0UXUBnf4eyR7SWlQwuWt+rO1FTuT0faZJKXRZymB8c1oOLGQl+gWRQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-render-info": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-render-info/-/unified-latex-util-render-info-1.4.2.tgz",
+      "integrity": "sha512-b5vZqpgo3yyH3zDww3PRUDp8DiDEampBRZ3xX7nXbG/B26s4fydToDbMHP5Q9r5YD/hsjGEgHZzGeb96kV997w==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-replace": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-replace/-/unified-latex-util-replace-1.4.2.tgz",
+      "integrity": "sha512-kUdd/M9guhSCQk485BIO7ysIeEENkq3wixVNPEViC1hxR5GjSXnPIqEX0IWTE3uwcPZzskuTiccYG+z46ELULg==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-split": "^1.4.2",
+        "@unified-latex/unified-latex-util-trim": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-scan": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-scan/-/unified-latex-util-scan-1.4.2.tgz",
+      "integrity": "sha512-veoarQeQVW1A/oSRCH7RI7qz410MecmT1NjzptNz982ODxWT9SS42QSraxm80R4bVooMxjv8r2P5ShlH5u7uWQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-print-raw": "^1.4.2",
+        "trie-prefix-tree": "^1.5.1"
+      }
+    },
+    "@unified-latex/unified-latex-util-split": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-split/-/unified-latex-util-split-1.4.2.tgz",
+      "integrity": "sha512-IQpUheQpd+jE3fjbzsubhySL80hSRlxix/23/b5h4hwEeBOWU2epAnKG9pcWjvd7xefIH4cvtPvcuqnzry8kcQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-trim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-trim/-/unified-latex-util-trim-1.4.2.tgz",
+      "integrity": "sha512-uAxX03qGnCD+e3jtX3wcjDPvD0amGQeIwCsvBQ1ONhODInq+aBMxf6t1UGC2LpPCmJqAaLevP0pSR39Fzw8zLA==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2",
+        "@unified-latex/unified-latex-util-render-info": "^1.4.2",
+        "@unified-latex/unified-latex-util-visit": "^1.4.2",
+        "unified": "^10.1.2"
+      }
+    },
+    "@unified-latex/unified-latex-util-visit": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@unified-latex/unified-latex-util-visit/-/unified-latex-util-visit-1.4.2.tgz",
+      "integrity": "sha512-rGqiqiQsyywAZC6rBGteJYE0nSDw/AGddwZWB/KgWvN6VYXZEY8UeBQjcqf01CmaRC8hDXjYk6Pw+By5XfQ4fQ==",
+      "requires": {
+        "@unified-latex/unified-latex-types": "^1.4.2",
+        "@unified-latex/unified-latex-util-match": "^1.4.2"
       }
     },
     "@vscode/test-electron": {
@@ -4594,6 +5248,11 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
+    },
+    "bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -4781,11 +5440,19 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -4793,8 +5460,16 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5284,6 +5959,11 @@
         "sort-keys-length": "^1.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5732,6 +6412,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-core-module": {
       "version": "2.13.0",
@@ -6526,6 +7211,11 @@
       "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
       "dev": true
     },
+    "prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6795,6 +7485,21 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7023,6 +7728,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "trie-prefix-tree": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/trie-prefix-tree/-/trie-prefix-tree-1.5.1.tgz",
+      "integrity": "sha512-Jjvj/dA97wXnabG/NLJUgo4IQMj6vucH+Qxm7of/omfWSmZlPqdRU6Ta4GmQqCZH+n3/iYZUwfvUoEhB0Hs83Q=="
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -7045,6 +7755,11 @@
           "dev": true
         }
       }
+    },
+    "trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
     },
     "tslib": {
       "version": "1.14.1",
@@ -7106,6 +7821,35 @@
         "through": "^2.3.8"
       }
     },
+    "unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        }
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
     "universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -7155,6 +7899,26 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -597,11 +597,14 @@
     "test": "node ./out/test/runTest.js"
   },
   "dependencies": {
+    "@unified-latex/unified-latex-prettier": "^2.4.2",
+    "@unified-latex/unified-latex-util-parse": "^1.4.2",
     "diff-match-patch": "^1.0.5",
     "form-data": "^4.0.0",
     "mime-types": "^2.1.35",
     "minimatch": "^9.0.3",
     "node-fetch": "^2.6.13",
+    "prettier": "^3.1.1",
     "socket.io-client": "github:overleaf/socket.io-client#0.9.17-overleaf-5",
     "uuid": "^9.0.1"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,6 @@ import { PdfViewEditorProvider } from './core/pdfViewEditorProvider';
 import { CompileManager } from './compile/compileManager';
 import { LangIntellisenseProvider } from './intellisense/langIntellisenseProvider';
 import { LocalReplicaSCMProvider } from './scm/localReplicaSCM';
-import { DocSymbolProvider } from './intellisense/texDocSymbolProvider';
-import { TexDocFormatter } from './intellisense/texDocFormatter';
 
 export function activate(context: vscode.ExtensionContext) {
     // Register: [core] RemoteFileSystemProvider
@@ -38,18 +36,6 @@ export function activate(context: vscode.ExtensionContext) {
     // Register: [intellisense] LangIntellisenseProvider
     const langIntellisenseProvider = new LangIntellisenseProvider(context, remoteFileSystemProvider);
     context.subscriptions.push( ...langIntellisenseProvider.triggers );
-
-    // Register: [intellisense] TexSymbolProvider
-    const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map( (id) => {
-       return {language: id };
-    });
-    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(latexSelector, new DocSymbolProvider()));
-
-    // Register: [intellisense] TexDocFormatter
-    const texDocFormatter = new TexDocFormatter();
-    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(latexSelector, texDocFormatter));
-    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(latexSelector, texDocFormatter));
-
 
     // activate vfs for local replica
     LocalReplicaSCMProvider.readSettings()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,8 @@ import { PdfViewEditorProvider } from './core/pdfViewEditorProvider';
 import { CompileManager } from './compile/compileManager';
 import { LangIntellisenseProvider } from './intellisense/langIntellisenseProvider';
 import { LocalReplicaSCMProvider } from './scm/localReplicaSCM';
+import { DocSymbolProvider } from './intellisense/texDocSymbolProvider';
+import { TexDocFormatter } from './intellisense/texDocFormatter';
 
 export function activate(context: vscode.ExtensionContext) {
     // Register: [core] RemoteFileSystemProvider
@@ -36,6 +38,18 @@ export function activate(context: vscode.ExtensionContext) {
     // Register: [intellisense] LangIntellisenseProvider
     const langIntellisenseProvider = new LangIntellisenseProvider(context, remoteFileSystemProvider);
     context.subscriptions.push( ...langIntellisenseProvider.triggers );
+
+    // Register: [intellisense] TexSymbolProvider
+    const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map( (id) => {
+       return {language: id };
+    });
+    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(latexSelector, new DocSymbolProvider()));
+
+    // Register: [intellisense] TexDocFormatter
+    const texDocFormatter = new TexDocFormatter();
+    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(latexSelector, texDocFormatter));
+    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(latexSelector, texDocFormatter));
+
 
     // activate vfs for local replica
     LocalReplicaSCMProvider.readSettings()

--- a/src/intellisense/langIntellisenseProvider.ts
+++ b/src/intellisense/langIntellisenseProvider.ts
@@ -3,6 +3,8 @@ import { ROOT_NAME, OUTPUT_FOLDER_NAME } from '../consts';
 import { SnippetItemSchema } from '../api/base';
 import { RemoteFileSystemProvider, VirtualFileSystem, parseUri } from '../core/remoteFileSystemProvider';
 import { EventBus } from '../utils/eventBus';
+import { DocSymbolProvider } from './texDocSymbolProvider';
+import { TexDocFormatter } from './texDocFormatter';
 
 type PathFileType = 'text' | 'image' | 'bib';
 
@@ -684,6 +686,8 @@ export class LangIntellisenseProvider extends IntellisenseProvider {
     private filePathCompletion: FilePathCompletionProvider;
     private misspellingCheck: MisspellingCheckProvider;
     private referenceCompletion: ReferenceCompletionProvider;
+    private docSymbolProvider: DocSymbolProvider = new DocSymbolProvider();
+    private texDocFormatter:TexDocFormatter = new TexDocFormatter();
 
     constructor(context: vscode.ExtensionContext, vfsm: RemoteFileSystemProvider) {
         super(vfsm);
@@ -722,12 +726,15 @@ export class LangIntellisenseProvider extends IntellisenseProvider {
             vscode.commands.registerCommand('langIntellisense.settings', () => {
                 this.misspellingCheck.spellCheckSettings();
             }),
+            
             // register other triggers
             ...this.commandCompletion.triggers,
             ...this.constantCompletion.triggers,
             ...this.filePathCompletion.triggers,
             ...this.misspellingCheck.triggers,
             ...this.referenceCompletion.triggers,
+            ...this.docSymbolProvider.triggers,
+            ...this.texDocFormatter.triggers,
         ];
     }
 }

--- a/src/intellisense/texDocFormatter.ts
+++ b/src/intellisense/texDocFormatter.ts
@@ -1,0 +1,52 @@
+
+import * as vscode from 'vscode';
+import * as Prettier from "prettier";
+import { prettierPluginLatex } from "@unified-latex/unified-latex-prettier";
+
+async function printPrettier(source = "", options = {}) {
+    return Prettier.format(source, {
+        printWidth: 80,
+        useTabs: true,
+        ...options,
+        parser: "latex-parser",
+        plugins: [prettierPluginLatex],
+    });
+}
+
+async function format(source: string) {
+    return await printPrettier(source);
+}
+
+
+export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
+    provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        // Get the entire document text
+        const text = document.getText();
+
+        // Format the LaTeX code here
+        return format(text).then(formattedText => {
+        // const formattedText = format(text);
+
+        // Create a TextEdit to replace the entire document text with the formatted text
+        const edit = new vscode.TextEdit(new vscode.Range(0, 0, document.lineCount, 0), formattedText);
+        // Return the TextEdit as an array
+        return [edit];
+        });
+
+    }
+
+    provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        // Get the selected text
+        const text = document.getText(range);
+
+        // Format the selected LaTeX code here
+        return format(text).then(formattedText => {
+
+        // Create a TextEdit to replace the selected text with the formatted text
+        const edit = new vscode.TextEdit(range, formattedText);
+        // Return the TextEdit as an array
+        return [edit];
+        });
+    }
+}
+

--- a/src/intellisense/texDocFormatter.ts
+++ b/src/intellisense/texDocFormatter.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as Prettier from "prettier";
 import { prettierPluginLatex } from "@unified-latex/unified-latex-prettier";
 
+// https://github.com/siefkenj/latex-parser-playground/blob/master/src/async-worker/parsing-worker.ts#L35-L43
 async function printPrettier(source = "", options = {}) {
     return Prettier.format(source, {
         printWidth: 80,
@@ -16,7 +17,6 @@ async function printPrettier(source = "", options = {}) {
 async function format(source: string) {
     return await printPrettier(source);
 }
-
 
 export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
     provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
@@ -32,7 +32,6 @@ export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
         // Return the TextEdit as an array
         return [edit];
         });
-
     }
 
     provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
@@ -47,6 +46,17 @@ export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
         // Return the TextEdit as an array
         return [edit];
         });
+    }
+
+    get triggers(){
+        const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map( (id) => {
+            return {language: id };
+         });
+        const texDocFormatter = new TexDocFormatter();
+        return[
+            vscode.languages.registerDocumentFormattingEditProvider(latexSelector, texDocFormatter),
+            vscode.languages.registerDocumentRangeFormattingEditProvider(latexSelector, texDocFormatter)
+        ];
     }
 }
 

--- a/src/intellisense/texDocFormatter.ts
+++ b/src/intellisense/texDocFormatter.ts
@@ -2,20 +2,24 @@
 import * as vscode from 'vscode';
 import * as Prettier from "prettier";
 import { prettierPluginLatex } from "@unified-latex/unified-latex-prettier";
+import { ROOT_NAME } from '../consts';
 
+
+/*
+    * @param {string} source - The LaTeX source code to be formatted.
+    * @param {object} options - The options for Prettier. 
+    *       printWidth (word) denote the number of space per line.
+    *       useTabs (boolean) denote whether to use tabs or spaces .
+    * @returns {Promise<string>} - The formatted LaTeX source code.
+*/
 // https://github.com/siefkenj/latex-parser-playground/blob/master/src/async-worker/parsing-worker.ts#L35-L43
-async function printPrettier(source = "", options = {}) {
+async function format(source = "", options: vscode.FormattingOptions ) {
     return Prettier.format(source, {
-        printWidth: 80,
-        useTabs: true,
-        ...options,
+        tabWidth: options.tabSize,
+        useTabs: !options?.insertSpaces,
         parser: "latex-parser",
         plugins: [prettierPluginLatex],
     });
-}
-
-async function format(source: string) {
-    return await printPrettier(source);
 }
 
 export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
@@ -24,9 +28,7 @@ export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
         const text = document.getText();
 
         // Format the LaTeX code here
-        return format(text).then(formattedText => {
-        // const formattedText = format(text);
-
+        return format(text, options).then(formattedText => {
         // Create a TextEdit to replace the entire document text with the formatted text
         const edit = new vscode.TextEdit(new vscode.Range(0, 0, document.lineCount, 0), formattedText);
         // Return the TextEdit as an array
@@ -39,7 +41,7 @@ export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
         const text = document.getText(range);
 
         // Format the selected LaTeX code here
-        return format(text).then(formattedText => {
+        return format(text, options).then(formattedText => {
 
         // Create a TextEdit to replace the selected text with the formatted text
         const edit = new vscode.TextEdit(range, formattedText);
@@ -50,12 +52,11 @@ export class TexDocFormatter implements vscode.DocumentFormattingEditProvider {
 
     get triggers(){
         const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map( (id) => {
-            return {language: id };
+            return {scheme: ROOT_NAME, language: id };
          });
-        const texDocFormatter = new TexDocFormatter();
         return[
-            vscode.languages.registerDocumentFormattingEditProvider(latexSelector, texDocFormatter),
-            vscode.languages.registerDocumentRangeFormattingEditProvider(latexSelector, texDocFormatter)
+            vscode.languages.registerDocumentFormattingEditProvider(latexSelector, this),
+            vscode.languages.registerDocumentRangeFormattingEditProvider(latexSelector, this),
         ];
     }
 }

--- a/src/intellisense/texDocSymbolProvider.ts
+++ b/src/intellisense/texDocSymbolProvider.ts
@@ -1,11 +1,18 @@
 import * as vscode from 'vscode';
 import type * as Ast from '@unified-latex/unified-latex-types';
 import * as unifiedLaTeXParse from '@unified-latex/unified-latex-util-parse';
+import { ROOT_NAME } from '../consts';
 
+// Initialize the parser
+let unifiedParser: { parse: (content: string) => Ast.Root } = unifiedLaTeXParse.getParser({ flags: { autodetectExpl3AndAtLetter: true } });
+
+// Env that matches the defaultStructure will be treated as a section with top-down order
 const defaultStructure = ["book", "part", "chapter", "section", "subsection", "subsubsection", "paragraph", "subparagraph"];
 
+// Match label command
 const defaultCMD = ["label"];
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 enum TeXElementType { Environment, Command, Section, SectionAst, SubFile, BibItem, BibField };
 
 type TeXElement = {
@@ -14,76 +21,17 @@ type TeXElement = {
     label: string,
     readonly lineFr: number,
     lineTo: number,
-    readonly filePath: string,
     children: TeXElement[],
     parent?: TeXElement,
     appendix?: boolean
 };
 
-type UnifiedParser = { parse: (content: string) => Ast.Root };
-
-type FileStructureCache = {
-    [filePath: string]: TeXElement[]
-};
-
-let unifiedParser: UnifiedParser = unifiedLaTeXParse.getParser({ flags: { autodetectExpl3AndAtLetter: true } });
-
-export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
-
-    async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
-        const sections = await construct(document);
-        return this.sectionToSymbols(sections);
-    }
-
-    private sectionToKind(section: TeXElement): vscode.SymbolKind {
-        if (section.type === TeXElementType.Section || section.type === TeXElementType.SectionAst) {
-            return vscode.SymbolKind.Struct;
-        }
-        if (section.type === TeXElementType.Environment) {
-            return vscode.SymbolKind.Package;
-        }
-        if (section.type === TeXElementType.Command) {
-            return vscode.SymbolKind.Number;
-        }
-        if (section.type === TeXElementType.SubFile) {
-            return vscode.SymbolKind.File;
-        }
-        if (section.type === TeXElementType.BibItem) {
-            return vscode.SymbolKind.Class;
-        }
-        if (section.type === TeXElementType.BibField) {
-            return vscode.SymbolKind.Constant;
-        }
-        return vscode.SymbolKind.String;
-    }
-
-    private sectionToSymbols(sections: TeXElement[]): vscode.DocumentSymbol[] {
-        const symbols: vscode.DocumentSymbol[] = [];
-
-        sections.forEach(section => {
-            const range = new vscode.Range(section.lineFr, 0, section.lineTo, 65535);
-            const symbol = new vscode.DocumentSymbol(
-                section.label || 'empty', '',
-                this.sectionToKind(section),
-                range, range);
-            symbols.push(symbol);
-            if (section.children.length > 0) {
-                symbol.children = this.sectionToSymbols(section.children);
-            }
-        });
-        return symbols;
-    }
-
-    get triggers(){
-        const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map( (id) => {
-            return {language: id };
-         });
-        return [
-            vscode.languages.registerDocumentSymbolProvider(latexSelector, new DocSymbolProvider())
-        ];
-    }
-}
-
+/* 
+    * Convert a macro to string
+    * 
+    * @param macro: the macro to be converted
+    * @return: the string representation of the macro
+*/
 // reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/utils/parser.ts#L3
 function macroToStr(macro: Ast.Macro): string {
     if (macro.content === 'texorpdfstring') {
@@ -92,10 +40,24 @@ function macroToStr(macro: Ast.Macro): string {
     return `\\${macro.content}` + (macro.args?.map(arg => `${arg.openMark}${argContentToStr(arg.content)}${arg.closeMark}`).join('') ?? '');
 }
 
+/*
+    * Convert an environment to string
+    * 
+    * @param env: the environment to be converted
+    * @return: the string representation of the environment
+*/
 function envToStr(env: Ast.Environment | Ast.VerbatimEnvironment): string {
     return `\\environment{${env.env}}`;
 }
 
+
+/*
+    * Convert the content of an argument to string
+    * 
+    * @param argContent: the content of the argument
+    * @param preserveCurlyBrace: whether to preserve the curly brace '{'
+    * @return: the string representation of the argument
+*/
 // reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/utils/parser.ts#L14
 function argContentToStr(argContent: Ast.Node[], preserveCurlyBrace: boolean = false): string {
     return argContent.map(node => {
@@ -127,23 +89,44 @@ function argContentToStr(argContent: Ast.Node[], preserveCurlyBrace: boolean = f
     }).join('');
 }
 
+
+/*
+    * Generate a tree-like structure from a LaTeX file
+    * 
+    * @param document: the LaTeX file
+    * @return: the tree-like TeXElement[] structure
+*/
 // reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L30
-export async function construct(document: vscode.TextDocument): Promise<TeXElement[]> {
+export async function genTexElements(document: vscode.TextDocument): Promise<TeXElement[]> {
     const filePath = document.fileName;
     if (filePath === undefined) {
         return [];
     }
-    const structs: FileStructureCache = {};
-    await constructFile(filePath, structs, document.getText());
-    // In rare cases, the following struct may be undefined. Typically in tests
-    // where roots are changed rapidly.
-    let struct =  structs[filePath];
-    struct = hierachyStructFormat(struct);
+    const rootElement = { children: [] };
+    let ast = await unifiedParser.parse(document.getText());
+    for (const node of ast.content) {
+        if (['string', 'parbreak', 'whitespace'].includes(node.type)) {
+            continue;
+        }
+        try {
+            await parseNode(node, rootElement);
+        }
+        catch (e) {
+            console.log(e);
+        }
+    }
+    let struct = rootElement.children as TeXElement[];
+    struct = hierarchyStructFormat(struct);
     return struct;
 }
 
-// Create Tree-like structure from flat TexElement[]
-function hierachyStructFormat(struct: TeXElement[]): TeXElement[] {
+/*
+    * Format the tree-like TeXElement[] structure based on the given order in defaultStructure
+    * 
+    * @param struct: the flat TeXElement[] structure
+    * @return: the formatted TeXElement[] structure
+*/
+function hierarchyStructFormat(struct: TeXElement[]): TeXElement[] {
     const newStruct: TeXElement[] = [];
     const orderFromDefaultStructure = new Map<string, number>();
     for (const [i, section] of defaultStructure.entries()) {
@@ -162,135 +145,223 @@ function hierachyStructFormat(struct: TeXElement[]): TeXElement[] {
             prev.children.push(section);
         } else {
             newStruct.push(section);
-            prev.children = hierachyStructFormat(prev.children);
+            prev.children = hierarchyStructFormat(prev.children);
             prev = section;
         }
     }
     if (prev !== undefined) {
-        prev.children = hierachyStructFormat(prev.children);
+        prev.children = hierarchyStructFormat(prev.children);
     }
     return newStruct;
 }
 
 
-// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L55
-async function constructFile(filePath: string, structs: FileStructureCache, fileContent:string): Promise<void> {
-    if (structs[filePath] !== undefined) {
-        return;
-    }
-    // Get a list of rnw child chunks
 
-    // Parse each base-level node. If the node has contents, that function
-    // will be called recursively.
-    const rootElement = { children: [] };
-    structs[filePath] = rootElement.children;
-    let ast = await unifiedParser.parse(fileContent);
-    
-    let inAppendix = false;
-    for (const node of ast.content) {
-        if (['string', 'parbreak', 'whitespace'].includes(node.type)) {
-            continue;
-        }
-        // Appendix is a one-way journey. Once in it, always in it.
-        try {
-            if (await parseNode(node, rootElement, filePath, structs, inAppendix)) {
-                inAppendix = true;
-            }
-        }
-        catch (e) {
-            console.log(e);
-        }
-    }
-}
-
+/*
+    * Parse a node and generate a TeXElement, this function travel each node recursively (Here children is referenced by `.content`),
+    * if the node is a macro and matches the defaultStructure, it will be treated as a section;
+    * if the node is a macro and matches the defaultCMD, it will be treated as a command;
+    * if the node is an environment, it will be treated as an environment;
+    * 
+    * @param node: the node to be parsed
+    * @param root: the root TeXElement
+*/
 // reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L86
 async function parseNode(
-        node: Ast.Node,
-        root: { children: TeXElement[] },
-        filePath: string,
-        structs: FileStructureCache,
-        inAppendix: boolean): Promise<boolean> {
+    node: Ast.Node,
+    root: { children: TeXElement[] }
+) {
     const attributes = {
         lineFr: (node.position?.start.line ?? 1) - 1,
         lineTo: (node.position?.end.line ?? 1) - 1,
-        filePath, children: []
+        children: []
     };
     let element: TeXElement | undefined;
-    if (node.type === 'macro'&& defaultStructure.includes(node.content) && node.args?.[3].openMark === '{') {
-        // To use a macro as an outline item, the macro must have an explicit
-        // mandatory argument e.g. \section{} instead of \section. This is to
-        // ignore cases like \titleformat{\section} when \titleformat is not
-        // globbing arguments in unified-latex.
-        element = {
-            type: node.args?.[0]?.content[0] ? TeXElementType.SectionAst : TeXElementType.Section,
-            name: node.content,
-            label: argContentToStr(((node.args?.[1]?.content?.length ?? 0) > 0 ? node.args?.[1]?.content : node.args?.[3]?.content) || []),
-            appendix: inAppendix,
-            ...attributes
-        };
-    } else if (node.type === 'macro' && defaultCMD.includes(node.content)) {
-        const argStr = argContentToStr(node.args?.[1]?.content || []);
-        element = {
-            type: TeXElementType.Command,
-            name: node.content,
-            label: `#${node.content}` + (argStr ? `: ${argStr}` : ''),
-            ...attributes
-        };
-    }else if (node.type === 'macro' && node.content === 'appendix') {
-        inAppendix = true;
-    }else if ((node.type === 'environment') && node.env === 'frame') {
-        const frameTitleMacro: Ast.Macro | undefined = node.content.find(sub => sub.type === 'macro' && sub.content === 'frametitle') as Ast.Macro | undefined;
-        const caption = argContentToStr(node.args?.[3]?.content || []) || argContentToStr(frameTitleMacro?.args?.[3]?.content || []);
-        element = {
-            type: TeXElementType.Environment,
-            name: node.env,
-            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`  + (caption ? `: ${caption}` : '') ,
-            ...attributes
-        };
-    } else if ((node.type === 'environment') && (
-                (node.env === 'figure' || node.env === 'figure*')  ||
-                (node.env === 'table' || node.env === 'table*'))) {
-        const captionMacro: Ast.Macro | undefined = node.content.find(sub => sub.type === 'macro' && sub.content === 'caption') as Ast.Macro | undefined;
-        const caption = argContentToStr(captionMacro?.args?.[1]?.content || []);
-        if (node.env.endsWith('*')) {
-            node.env = node.env.slice(0, -1);
-        }
-        element = {
-            type: TeXElementType.Environment,
-            name: node.env,
-            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` + (caption ? `: ${caption}` : ''),
-            ...attributes
-        };
-    } else if ((node.type === 'environment') && (node.env === 'macro' || node.env === 'environment')) {
-        // DocTeX: \begin{macro}{<macro>}
-        const caption = (node.content[0] as Ast.Group | undefined)?.content[0] as Ast.String | undefined;
-        element = {
-            type: TeXElementType.Environment,
-            name: node.env,
-            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` + (caption ? `: ${caption}` : ''),
-            ...attributes
-        };
-    } else if (node.type === 'environment' || node.type === 'mathenv') {
-        element = {
-            type: TeXElementType.Environment,
-            name: node.env,
-            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`,
-            ...attributes
-        };
-    } 
-    
+    let caption = '';
+    switch (node.type) {
+        case 'macro':
+            let caseType = '';
+            if (defaultStructure.includes(node.content) && node.args?.[3].openMark === '{') {
+                caseType = 'section';
+            } else if (defaultCMD.includes(node.content)) {
+                caseType = 'label';
+            } else if (node.content === 'input') {
+                caseType = 'subfile';
+            }
+            let argStr = '';
+            switch (caseType) {
+                case 'section':
+                    element = {
+                        type: node.args?.[0]?.content[0]
+                            ? TeXElementType.SectionAst
+                            : TeXElementType.Section,
+                        name: node.content,
+                        label: argContentToStr(
+                            ((node.args?.[1]?.content?.length ?? 0) > 0
+                                ? node.args?.[1]?.content
+                                : node.args?.[3]?.content) || []
+                        ),
+                        ...attributes
+                    };
+                    break;
+                case 'label':
+                    argStr = argContentToStr(node.args?.[2]?.content || []);
+                    element = {
+                        type: TeXElementType.Command,
+                        name: node.content,
+                        label: `${node.content}` + (argStr ? `: ${argStr}` : ''),
+                        ...attributes
+                    };
+                    break;
+                case 'subfile':
+                    argStr = argContentToStr(node.args?.[0]?.content || []);
+                    element = {
+                        type: TeXElementType.SubFile,
+                        name: node.content,
+                        label: argStr ? `${argStr}` : '',
+                        ...attributes
+                    };
+                    break;
+                }
+            break;
+        case 'environment':
+            switch (node.env) {
+                case 'frame':
+                    const frameTitleMacro: Ast.Macro | undefined = node.content.find(
+                        sub => sub.type === 'macro' && sub.content === 'frametitle'
+                    ) as Ast.Macro | undefined;
+                    caption = argContentToStr(node.args?.[3]?.content || []) ||
+                        argContentToStr(frameTitleMacro?.args?.[3]?.content || []);
+                    element = {
+                        type: TeXElementType.Environment,
+                        name: node.env,
+                        label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` +
+                            (caption ? `: ${caption}` : ''),
+                        ...attributes
+                    };
+                    break;
+
+                case 'figure':
+                case 'figure*':
+                case 'table':
+                case 'table*':
+                    const captionMacro: Ast.Macro | undefined = node.content.find(
+                        sub => sub.type === 'macro' && sub.content === 'caption'
+                    ) as Ast.Macro | undefined;
+                    caption = argContentToStr(captionMacro?.args?.[1]?.content || []);
+                    if (node.env.endsWith('*')) {
+                        node.env = node.env.slice(0, -1);
+                    }
+                    element = {
+                        type: TeXElementType.Environment,
+                        name: node.env,
+                        label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` +
+                            (caption ? `: ${caption}` : ''),
+                        ...attributes
+                    };
+                    break;
+
+                case 'macro':
+                case 'environment':
+                default:
+                    if (defaultStructure.includes(node.env)) {
+                        const caption = (node.content[0] as Ast.Group | undefined)?.content[0] as Ast.String | undefined;
+                        element = {
+                            type: TeXElementType.Environment,
+                            name: node.env,
+                            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` +
+                                (caption ? `: ${caption.content}` : ''),
+                            ...attributes
+                        };
+                    } else {
+                        element = {
+                            type: TeXElementType.Environment,
+                            name: node.env,
+                            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`,
+                            ...attributes
+                        };
+                    }
+                    break;
+            }
+            break;
+
+        case 'mathenv':
+            switch (node.env) {
+                case 'string':
+                    element = {
+                        type: TeXElementType.Environment,
+                        name: node.env,
+                        label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`,
+                        ...attributes
+                    };
+                    break;
+            }
+            break;
+    }
+
     if (element !== undefined) {
         root.children.push(element);
         root = element;
     }
+
     if ('content' in node && typeof node.content !== 'string') {
         for (const sub of node.content) {
             if (['string', 'parbreak', 'whitespace'].includes(sub.type)) {
                 continue;
             }
-            inAppendix = await parseNode(sub, root, filePath, structs, inAppendix);
+            await parseNode(sub, root);
         }
     }
-    return inAppendix;
 }
 
+export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
+    async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
+        const sections = await genTexElements(document);
+        return this.elementsToSymbols(sections);
+    }
+
+    private elementsTypeCast(section: TeXElement): vscode.SymbolKind {
+        switch (section.type){
+            case TeXElementType.Section:
+            case TeXElementType.SectionAst:
+                return vscode.SymbolKind.Struct;
+            case TeXElementType.Environment:
+                return vscode.SymbolKind.Package;
+            case TeXElementType.Command:
+                return vscode.SymbolKind.Number;
+            case TeXElementType.SubFile:
+                return vscode.SymbolKind.File;
+            case TeXElementType.BibItem:
+                return vscode.SymbolKind.Class;
+            case TeXElementType.BibField:
+                return vscode.SymbolKind.Constant;
+            default:
+                return vscode.SymbolKind.String;
+        }
+    }
+
+    private elementsToSymbols(sections: TeXElement[]): vscode.DocumentSymbol[] {
+        const symbols: vscode.DocumentSymbol[] = [];
+        sections.forEach(section => {
+            const range = new vscode.Range(section.lineFr, 0, section.lineTo, 65535);
+            const symbol = new vscode.DocumentSymbol(
+                section.label || 'empty', '',
+                this.elementsTypeCast(section),
+                range, range);
+            symbols.push(symbol);
+            if (section.children.length > 0) {
+                symbol.children = this.elementsToSymbols(section.children);
+            }
+        });
+        return symbols;
+    }
+
+    get triggers(){
+        const latexSelector = ['latex', 'latex-expl3', 'pweave', 'jlweave', 'rsweave'].map((id) => {
+            return {scheme: ROOT_NAME, language: id };
+        });
+        return [
+            vscode.languages.registerDocumentSymbolProvider(latexSelector, this),
+        ];
+    }
+}

--- a/src/intellisense/texDocSymbolProvider.ts
+++ b/src/intellisense/texDocSymbolProvider.ts
@@ -1,0 +1,286 @@
+import * as vscode from 'vscode';
+import type * as Ast from '@unified-latex/unified-latex-types';
+import * as unifiedLaTeXParse from '@unified-latex/unified-latex-util-parse';
+
+const defaultStructure = ["book", "part", "chapter", "section", "subsection", "subsubsection", "paragraph", "subparagraph"];
+
+const defaultCMD = ["label"];
+
+enum TeXElementType { Environment, Command, Section, SectionAst, SubFile, BibItem, BibField };
+
+type TeXElement = {
+    readonly type: TeXElementType,
+    readonly name: string,
+    label: string,
+    readonly lineFr: number,
+    lineTo: number,
+    readonly filePath: string,
+    children: TeXElement[],
+    parent?: TeXElement,
+    appendix?: boolean
+};
+
+type UnifiedParser = { parse: (content: string) => Ast.Root };
+
+type FileStructureCache = {
+    [filePath: string]: TeXElement[]
+};
+
+let unifiedParser: UnifiedParser = unifiedLaTeXParse.getParser({ flags: { autodetectExpl3AndAtLetter: true } });
+
+export class DocSymbolProvider implements vscode.DocumentSymbolProvider {
+
+    async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.DocumentSymbol[]> {
+        const sections = await construct(document);
+        return this.sectionToSymbols(sections);
+    }
+
+    private sectionToKind(section: TeXElement): vscode.SymbolKind {
+        if (section.type === TeXElementType.Section || section.type === TeXElementType.SectionAst) {
+            return vscode.SymbolKind.Struct;
+        }
+        if (section.type === TeXElementType.Environment) {
+            return vscode.SymbolKind.Package;
+        }
+        if (section.type === TeXElementType.Command) {
+            return vscode.SymbolKind.Number;
+        }
+        if (section.type === TeXElementType.SubFile) {
+            return vscode.SymbolKind.File;
+        }
+        if (section.type === TeXElementType.BibItem) {
+            return vscode.SymbolKind.Class;
+        }
+        if (section.type === TeXElementType.BibField) {
+            return vscode.SymbolKind.Constant;
+        }
+        return vscode.SymbolKind.String;
+    }
+
+    private sectionToSymbols(sections: TeXElement[]): vscode.DocumentSymbol[] {
+        const symbols: vscode.DocumentSymbol[] = [];
+
+        sections.forEach(section => {
+            const range = new vscode.Range(section.lineFr, 0, section.lineTo, 65535);
+            const symbol = new vscode.DocumentSymbol(
+                section.label || 'empty', '',
+                this.sectionToKind(section),
+                range, range);
+            symbols.push(symbol);
+            if (section.children.length > 0) {
+                symbol.children = this.sectionToSymbols(section.children);
+            }
+        });
+        return symbols;
+    }
+}
+
+// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/utils/parser.ts#L3
+function macroToStr(macro: Ast.Macro): string {
+    if (macro.content === 'texorpdfstring') {
+        return (macro.args?.[1].content[0] as Ast.String | undefined)?.content || '';
+    }
+    return `\\${macro.content}` + (macro.args?.map(arg => `${arg.openMark}${argContentToStr(arg.content)}${arg.closeMark}`).join('') ?? '');
+}
+
+function envToStr(env: Ast.Environment | Ast.VerbatimEnvironment): string {
+    return `\\environment{${env.env}}`;
+}
+
+// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/utils/parser.ts#L14
+function argContentToStr(argContent: Ast.Node[], preserveCurlyBrace: boolean = false): string {
+    return argContent.map(node => {
+        // Verb
+        switch (node.type) {
+            case 'string':
+                return node.content;
+            case 'whitespace':
+            case 'parbreak':
+            case 'comment':
+                return ' ';
+            case 'macro':
+                return macroToStr(node);
+            case 'environment':
+            case 'verbatim':
+            case 'mathenv':
+                return envToStr(node);
+            case 'inlinemath':
+                return `$${argContentToStr(node.content)}$`;
+            case 'displaymath':
+                return `\\[${argContentToStr(node.content)}\\]`;
+            case 'group':
+                return preserveCurlyBrace ? `{${argContentToStr(node.content)}}` : argContentToStr(node.content);
+            case 'verb':
+                return node.content;
+            default:
+                return '';
+        }
+    }).join('');
+}
+
+// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L30
+export async function construct(document: vscode.TextDocument): Promise<TeXElement[]> {
+    const filePath = document.fileName;
+    if (filePath === undefined) {
+        return [];
+    }
+    const structs: FileStructureCache = {};
+    await constructFile(filePath, structs, document.getText());
+    // In rare cases, the following struct may be undefined. Typically in tests
+    // where roots are changed rapidly.
+    let struct =  structs[filePath];
+    struct = hierachyStructFormat(struct);
+    return struct;
+}
+
+// Create Tree-like structure from flat TexElement[]
+function hierachyStructFormat(struct: TeXElement[]): TeXElement[] {
+    const newStruct: TeXElement[] = [];
+    const orderFromDefaultStructure = new Map<string, number>();
+    for (const [i, section] of defaultStructure.entries()) {
+        orderFromDefaultStructure.set(section, i);
+    }
+    let prev: TeXElement | undefined;
+    for (const section of struct) {
+        // Root Node
+        if (prev === undefined) {
+            newStruct.push(section);
+            prev = section;
+            continue;
+        }
+        // Comparing the order of current section and previous section from defaultStructure
+        if ((orderFromDefaultStructure.get(section.name) ?? defaultStructure.length) > (orderFromDefaultStructure.get(prev.name) ?? defaultStructure.length)) {
+            prev.children.push(section);
+        } else {
+            newStruct.push(section);
+            prev = section;
+        }
+    }
+    return newStruct;
+}
+
+// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L55
+async function constructFile(filePath: string, structs: FileStructureCache, fileContent:string): Promise<void> {
+    if (structs[filePath] !== undefined) {
+        return;
+    }
+    // Get a list of rnw child chunks
+
+    // Parse each base-level node. If the node has contents, that function
+    // will be called recursively.
+    const rootElement = { children: [] };
+    structs[filePath] = rootElement.children;
+    let ast = await unifiedParser.parse(fileContent);
+
+    let inAppendix = false;
+    for (const node of ast.content) {
+        if (['string', 'parbreak', 'whitespace'].includes(node.type)) {
+            continue;
+        }
+        // Appendix is a one-way journey. Once in it, always in it.
+        try {
+            if (await parseNode(node, rootElement, filePath, structs, inAppendix)) {
+                inAppendix = true;
+            }
+        }
+        catch (e) {
+            console.log(e);
+        }
+    }
+}
+
+// reference: https://github.com/James-Yu/LaTeX-Workshop/blob/master/src/outline/structurelib/latex.ts#L86
+async function parseNode(
+        node: Ast.Node,
+        root: { children: TeXElement[] },
+        filePath: string,
+        structs: FileStructureCache,
+        inAppendix: boolean): Promise<boolean> {
+    const attributes = {
+        lineFr: (node.position?.start.line ?? 1) - 1,
+        lineTo: (node.position?.end.line ?? 1) - 1,
+        filePath, children: []
+    };
+    let element: TeXElement | undefined;
+    if (node.type === 'macro'&& defaultStructure.includes(node.content) && node.args?.[3].openMark === '{') {
+        // To use a macro as an outline item, the macro must have an explicit
+        // mandatory argument e.g. \section{} instead of \section. This is to
+        // ignore cases like \titleformat{\section} when \titleformat is not
+        // globbing arguments in unified-latex.
+        element = {
+            type: node.args?.[0]?.content[0] ? TeXElementType.SectionAst : TeXElementType.Section,
+            name: node.content,
+            label: argContentToStr(((node.args?.[1]?.content?.length ?? 0) > 0 ? node.args?.[1]?.content : node.args?.[3]?.content) || []),
+            appendix: inAppendix,
+            ...attributes
+        };
+    } else if (node.type === 'macro' && defaultCMD.includes(node.content)) {
+        const argStr = argContentToStr(node.args?.[1]?.content || []);
+        element = {
+            type: TeXElementType.Command,
+            name: node.content,
+            label: `#${node.content}` + (argStr ? `: ${argStr}` : ''),
+            ...attributes
+        };
+    }else if (node.type === 'macro' && node.content === 'appendix') {
+        inAppendix = true;
+    }else if ((node.type === 'environment') && node.env === 'frame') {
+        const frameTitleMacro: Ast.Macro | undefined = node.content.find(sub => sub.type === 'macro' && sub.content === 'frametitle') as Ast.Macro | undefined;
+        const caption = argContentToStr(node.args?.[3]?.content || []) || argContentToStr(frameTitleMacro?.args?.[3]?.content || []);
+        element = {
+            type: TeXElementType.Environment,
+            name: node.env,
+            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`  + (caption ? `: ${caption}` : '') ,
+            ...attributes
+        };
+    } else if ((node.type === 'environment') && (
+                (node.env === 'figure' || node.env === 'figure*')  ||
+                (node.env === 'table' || node.env === 'table*'))) {
+        const captionMacro: Ast.Macro | undefined = node.content.find(sub => sub.type === 'macro' && sub.content === 'caption') as Ast.Macro | undefined;
+        const caption = argContentToStr(captionMacro?.args?.[1]?.content || []);
+        if (node.env.endsWith('*')) {
+            node.env = node.env.slice(0, -1);
+        }
+        element = {
+            type: TeXElementType.Environment,
+            name: node.env,
+            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` + (caption ? `: ${caption}` : ''),
+            ...attributes
+        };
+    } else if ((node.type === 'environment') && (node.env === 'macro' || node.env === 'environment')) {
+        // DocTeX: \begin{macro}{<macro>}
+        const caption = (node.content[0] as Ast.Group | undefined)?.content[0] as Ast.String | undefined;
+        element = {
+            type: TeXElementType.Environment,
+            name: node.env,
+            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}` + (caption ? `: ${caption}` : ''),
+            ...attributes
+        };
+    } else if (node.type === 'environment' || node.type === 'mathenv') {
+        element = {
+            type: TeXElementType.Environment,
+            name: node.env,
+            label: `${node.env.charAt(0).toUpperCase()}${node.env.slice(1)}`,
+            ...attributes
+        };
+    } 
+    
+    if (element !== undefined) {
+        root.children.push(element);
+        root = element;
+    }
+    if ('content' in node && typeof node.content !== 'string') {
+        for (const sub of node.content) {
+            if (['string', 'parbreak', 'whitespace'].includes(sub.type)) {
+                continue;
+            }
+            inAppendix = await parseNode(sub, root, filePath, structs, inAppendix);
+        }
+    }
+    return inAppendix;
+}
+
+
+
+// function get
+


### PR DESCRIPTION
ADD an outline symbol provider and a default code formatter.

## Symbol Provider
After get a document:

`document` --> `genTexElements()` --> `TeXElement[]` --> `elementsToSymbols()` --> `vscode.DocumentSymbol[]`

The `document` will first be parsed by `parse` into `Ast.node`, after that, `parseNode()` iteratively parse the node into a vector `TeXElement[]`. The `TeXElement[]` will be further propossed by `hierarchyStructFormat()` to offer a structured symbol tree.

During `genTexElements()`, three helpers `macroToStr()`,  `envToStr()` and `argContentToStr()` convert arguments of node, which parsed by unified-latex from document, to string.

## Code Formatter
Use the prettier offered by `unified-latex`