### PR TITLE
[Intellisense] Extended Feature: support citation intellisense from .bib file

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,5 +4,3 @@ export const ROOT_NAME = 'overleaf-workshop';
 export const ELEGANT_NAME = 'Overleaf Workshop';
 
 export const OUTPUT_FOLDER_NAME = vscode.workspace.getConfiguration('overleaf-workshop').get('compileOutputFolderName', '.output') || '.output';
-
-export const BIB_ENTRY = 'bib-file';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,3 +4,5 @@ export const ROOT_NAME = 'overleaf-workshop';
 export const ELEGANT_NAME = 'Overleaf Workshop';
 
 export const OUTPUT_FOLDER_NAME = vscode.workspace.getConfiguration('overleaf-workshop').get('compileOutputFolderName', '.output') || '.output';
+
+export const BIB_ENTRY = 'bib-file';

--- a/src/intellisense/langIntellisenseProvider.ts
+++ b/src/intellisense/langIntellisenseProvider.ts
@@ -709,7 +709,7 @@ export class LangIntellisenseProvider extends IntellisenseProvider {
     private filePathCompletion: FilePathCompletionProvider;
     private misspellingCheck: MisspellingCheckProvider;
     private referenceCompletion: ReferenceCompletionProvider;
-    private docSymbolProvider: DocSymbolProvider = new DocSymbolProvider();
+    private docSymbolProvider: DocSymbolProvider ;
     private texDocFormatter:TexDocFormatter = new TexDocFormatter();
 
     constructor(context: vscode.ExtensionContext, vfsm: RemoteFileSystemProvider) {
@@ -719,6 +719,7 @@ export class LangIntellisenseProvider extends IntellisenseProvider {
         this.filePathCompletion = new FilePathCompletionProvider(vfsm);
         this.misspellingCheck = new MisspellingCheckProvider(vfsm);
         this.referenceCompletion = new ReferenceCompletionProvider(vfsm);
+        this.docSymbolProvider = new DocSymbolProvider(vfsm);
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -2);
         this.activate();
     }


### PR DESCRIPTION
> resolve #61 

### TODO
- [x] Add appendix file extraction from symbol provider.
- [x]  Dynamically read the root file.
- [x] Read bib item from bib file in the project

### Drawbacks
- Currently, the finding to search bibFile need an initialization to seach along the included files to compute the PDF which cause sometime.
- The bibFile now do not support multiple '.bib' ending like using `reference.bib` to represent `reference.bib.bib` where here only `reference.bib` is identified.
### Modifications
- `SymbolBibCache`, which is a collection of two maps that maintain tracking to document symbols and bib files path.
- In `DocSymbolProvider`, the `SymbolBibCache` is initialized if the root_id is not stored in the key. The initialization follows a tracking of the sequence of input-file symbols iteratively.
- In `texDocSymbolProvider.ts`, the `parseNode` function is added with additional case processing - `caseType = 'bibFile';` to identify the `.bib` file.
- `ReferenceCompletionProvider` is now constructed with the `DocSymbolProvider` which offers a bibfile  listing method.
- In `ReferenceCompletionProvider`, func `getBibCompletionItems` is used to extract the bibItems from the imput bib file path.
- In `ReferenceCompletionProvider`, func `formatPath` is used to parse the bib file path listed in the document to a valid path name which can be used to extract bibItems.