### PR TITLE
Auto vsce publish

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,6 +4,6 @@ We use Github Actions to automate various tasks in this repository. The followin
 
 - **lock-threads.yml**: Locks closed issues and pull requests after a period of inactivity.
 
-- **vsce-package.yml**: *TODO*
+- **vsce-package.yml**: Call `vsce package` to create a temporary VSCode extension package when a Pull Request is created/updated on the `master` branch.
 
-- **vsce-publish.yml**: *TODO*
+- **vsce-publish.yml**: Call `vsce publish` to publish the VSCode extension to the VSCode Marketplace when version tag is pushed on the `master` branch.

--- a/.github/workflows/vsce-publish.yml
+++ b/.github/workflows/vsce-publish.yml
@@ -1,0 +1,35 @@
+name: Publish Extension
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: | 
+          npm install
+          cd views/chat-view
+          npm install
+
+    - name: Install vsce
+      run: npm install -g vsce
+
+    - name: Publish
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      run: vsce publish -p $VSCE_PAT


### PR DESCRIPTION
This PR adds a github action `vsce-publish` to automatically publish then extension to Marketplace when version tag is pushed on the `master` branch.

This PR also updates the workflows documentation in `.github/workflows/READM.md` .