### PR TITLE
[Fix] Local Replica Unexpected Behavior

### DIFF
--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -370,10 +370,11 @@ export class VirtualFileSystem extends vscode.Disposable {
             onFileCreated: (parentFolderId:string, type:FileType, entity:FileEntity) => {
                 const res = this._resolveById(parentFolderId);
                 if (res) {
-                    const {fileEntity} = res;
+                    const {fileEntity,path} = res;
+                    const entityPath = path + entity.name;
                     this.insertEntity(fileEntity as FolderEntity, type, entity);
                     this.notify([
-                        {type: vscode.FileChangeType.Created, uri: this.pathToUri(res.path)}
+                        {type: vscode.FileChangeType.Created, uri: this.pathToUri(entityPath)}
                     ]);
                 }
             },

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -420,7 +420,7 @@ export class VirtualFileSystem extends vscode.Disposable {
                 const doc = res.fileEntity as DocumentEntity;
                 if (update.v===doc.version) {
                     doc.version += 1;
-                    if (update.op && doc.remoteCache) {
+                    if (update.op && doc.remoteCache!==undefined) {
                         let content = doc.remoteCache;
                         update.op.forEach((op) => {
                             if (op.i) {
@@ -513,7 +513,7 @@ export class VirtualFileSystem extends vscode.Disposable {
 
         if (fileType==='doc') {
             const doc = fileEntity as DocumentEntity;
-            if (doc.remoteCache) {
+            if (doc.remoteCache!==undefined) {
                 const content = doc.remoteCache;
                 EventBus.fire('fileWillOpenEvent', {uri});
                 return new TextEncoder().encode(content);
@@ -734,7 +734,7 @@ export class VirtualFileSystem extends vscode.Disposable {
         if (fileType && fileType==='doc' && fileEntity) {
             const doc = fileEntity as DocumentEntity;
             const _content = new TextDecoder().decode(content);
-            if (doc.version===undefined || doc.localCache===undefined || doc.remoteCache === undefined) {
+            if (doc.version===undefined || doc.localCache===undefined || doc.remoteCache===undefined) {
                 return;
             }
             const dmp = new DiffMatchPatch();

--- a/src/scm/localReplicaSCM.ts
+++ b/src/scm/localReplicaSCM.ts
@@ -15,7 +15,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
 
     public readonly iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('folder-library');
 
-    private syncCache: string[] = [];
+    private bypassCache: Map<string, number> = new Map();
     private baseCache: {[key:string]: Uint8Array} = {};
     private vfsWatcher?: vscode.FileSystemWatcher;
     private localWatcher?: vscode.FileSystemWatcher;
@@ -133,6 +133,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
                 const localContent = await this.readFile(relPath);
                 const remoteContent = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(vfsUri, name));
                 if (baseContent===undefined || localContent===undefined) {
+                    this.bypassCache.set(`pull ${relPath}`, Date.now());
                     await this.writeFile(relPath, remoteContent);
                 } else {
                     const dmp = new DiffMatchPatch();
@@ -155,46 +156,54 @@ export class LocalReplicaSCMProvider extends BaseSCM {
         }
     }
 
-    private bypassSync(relPath: string, type: 'update'|'delete'): boolean {
+    private bypassSync(status:'push'|'pull', relPath: string, type: 'update'|'delete'): boolean {
+        const bypassKey = status==='push'? 'pull' : 'push';
+
         // bypass ignore files
         if (this.matchIgnorePatterns(relPath)) {
             return true;
         }
 
-        // bypass loop call
-        const key = `${type} ${relPath}`;
-        if (this.syncCache.includes(key)) {
-            this.syncCache = this.syncCache.filter(item => item!==key);
-            return true;
+        // avoid loop call (inactivate within 500ms)
+        const key = `${bypassKey} ${relPath}`;
+        if (this.bypassCache.has(key)) {
+            const lastTime = this.bypassCache.get(key)!;
+            if (Date.now() - lastTime < 500) {
+                return true;
+            }
         }
 
         return false;
+    }
+
+    private async applySync(status:'push'|'pull', relPath:string, fromUri: vscode.Uri, toUri: vscode.Uri, type: 'update'|'delete') {
+        // bypass loop call
+        if (this.bypassSync(status, relPath, type)) { return; }
+        this.bypassCache.set(`${status} ${relPath}`, Date.now());
+        console.log(`${new Date().toLocaleString()} [${status}] ${type} "${relPath}"`);
+
+        // apply update
+        this.status = {status: status, message: `${type}: ${relPath}`};
+        if (type === 'update') {
+            const stat = await vscode.workspace.fs.stat(fromUri);
+            if (stat.type===vscode.FileType.File) {
+                const content = await vscode.workspace.fs.readFile(fromUri);
+                await vscode.workspace.fs.writeFile(toUri, content);
+                this.baseCache[relPath] = content;
+            } else if (stat.type===vscode.FileType.Directory) {
+                await vscode.workspace.fs.createDirectory(toUri);
+            }
+        } else {
+            await vscode.workspace.fs.delete(toUri, {recursive:true});
+        }
+        this.status = {status: 'idle', message: ''};
     }
 
     private async syncFromVFS(vfsUri: vscode.Uri, type: 'update'|'delete') {
         const {pathParts} = parseUri(vfsUri);
         const relPath = '/' + pathParts.join('/');
         const localUri = vscode.Uri.joinPath(this.baseUri, relPath);
-
-        if (this.bypassSync(relPath, type)) { return; }
-        this.syncCache.push(`${type} ${relPath}`);
-        console.log(`${new Date().toLocaleString()} ${type}: ${relPath} --> ${localUri.path}`);
-
-        // apply update
-        this.status = {status: 'pull', message: `${type}: ${relPath}`};
-        if (type === 'update') {
-            const stat = await vscode.workspace.fs.stat(vfsUri);
-            if (stat.type===vscode.FileType.File) {
-                const content = await vscode.workspace.fs.readFile(vfsUri);
-                await this.writeFile(relPath, content);
-                this.baseCache[relPath] = content;
-            } else if (stat.type===vscode.FileType.Directory) {
-                await vscode.workspace.fs.createDirectory(localUri);
-            }
-        } else {
-            await vscode.workspace.fs.delete(localUri, {recursive:true});
-        }
-        this.status = {status: 'idle', message: ''};
+        this.applySync('pull', relPath, vfsUri, localUri, type);
     }
 
     private async syncToVFS(localUri: vscode.Uri, type: 'update'|'delete') {
@@ -202,26 +211,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
         const basePath = this.baseUri.path;
         const relPath = localUri.path.slice(basePath.length);
         const vfsUri = this.vfs.pathToUri(relPath);
-
-        if (this.bypassSync(relPath, type)) { return; }
-        this.syncCache.push(`${type} ${relPath}`);
-        console.log(`${new Date().toLocaleString()} ${type}: ${relPath} --> ${vfsUri.toString()}`);
-
-        // apply update
-        this.status = {status: 'push', message: `${type}: ${relPath}`};
-        if (type === 'update') {
-            const stat = await vscode.workspace.fs.stat(localUri);
-            if (stat.type===vscode.FileType.File) {
-                const content = await vscode.workspace.fs.readFile(localUri);
-                await vscode.workspace.fs.writeFile(vfsUri, content);
-                this.baseCache[relPath] = content;
-            } else if (stat.type===vscode.FileType.Directory) {
-                await vscode.workspace.fs.createDirectory(vfsUri);
-            }
-        } else {
-            await vscode.workspace.fs.delete(localUri, {recursive:true});
-        }
-        this.status = {status: 'idle', message: ''};
+        this.applySync('push', relPath, localUri, vfsUri, type);
     }
 
     private async initWatch() {
@@ -240,13 +230,13 @@ export class LocalReplicaSCMProvider extends BaseSCM {
             ));
         }
 
-        await this.overwrite();
         this.vfsWatcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern( this.vfs.origin, '**/*' )
         );
         this.localWatcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern( this.baseUri.path, '**/*' )
         );
+        await this.overwrite();
 
         return [
             // sync from vfs to local


### PR DESCRIPTION
> resolves #88 

- [x] bypass local replica initial overwrite events
- [x] handle "delete-then-update" or "update-then-delete" file overwrite behavior
- [x] remote file replace only update parent folder instead of the file
- [x] create a file locally/remotely and edit, the changes are not synced to remote/local;