### PR TITLE
[Intellisense] Support citation intellisense from .bib file

### DIFF
--- a/src/intellisense/texDocSymbolCache.ts
+++ b/src/intellisense/texDocSymbolCache.ts
@@ -1,0 +1,51 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export enum TeXElementType { Environment, Command, Section, SectionAst, SubFile, BibItem, BibField, BibFile};
+
+export type TeXElement = {
+    readonly type: TeXElementType,
+    readonly name: string,
+    label: string,
+    readonly lineFr: number,
+    lineTo: number,
+    children: TeXElement[],
+    parent?: TeXElement,
+    appendix?: boolean,
+};
+
+export type FileCache = {
+    filePath : string,
+    fileContent: string,
+    texElements: TeXElement[],
+    childrenPaths: string[],
+    bibFilePaths: string[],
+};
+
+export class ProjectCache {
+    private fileNodeCache: Map<string, FileCache> = new Map<string, FileCache>();
+
+    public getFileCache(filePath: string): FileCache | undefined {
+        return this.fileNodeCache.get(filePath);
+    }
+    
+    public updateCache(childNode: FileCache): void {
+        this.fileNodeCache.set(childNode.filePath, childNode);
+    }
+
+    public getBibFilePaths(rootPath:string): string[] {
+        const fileQueue: FileCache[] = this.fileNodeCache.has(rootPath) ? [this.fileNodeCache.get(rootPath) as FileCache] : [];
+        const bibFilePaths: string[] = [];
+        // iteratively traverse file node tree
+        while (fileQueue.length > 0) {
+            const fileNode = fileQueue.shift() as FileCache;
+            if (fileNode.bibFilePaths.length > 0) {
+                bibFilePaths.push(...fileNode.bibFilePaths);
+            }
+            fileNode.childrenPaths.forEach( child => {
+                if (this.fileNodeCache.has(child)){
+                    fileQueue.push(this.fileNodeCache.get(child) as FileCache);
+                };
+            });
+        }
+        return bibFilePaths;
+    }
+}


### PR DESCRIPTION
> resolve #61 
This PR is aim to support bib entry completition from bib file.

## TODOS

- [x]  Provide a cache structure to store the file symbols in the project, which can be used to find imported `.bib` file.
- [x]  Provide construction of cache structure from symbol providing
- [x]  Provide bibItem completion from `.bib` file

## Modification
### `src/intellisense/texDocSymbolCache.ts`
In this file, define type -- `FileCache`, Class -- `ProjectCache`
- `FileCache`, stores the parsed file content:
  -  `filePath`, used to identify each file.
  -  `fileContent`, a copy of `.tex` file content
  -  `texElements`, symbols extracted from `parseNode` in `texDocSymbolProvider.ts`
  -  `bibFilePaths`, the file name of bib file used in this `.tex` file
  -  `childrenPaths`, the file name of inported file
- `ProjectCache`, the cache to store the data from project
  - `fileNodeCache` which is a map `Map<string, FileNode>` used to reduced the time required to get each node.
  - Func `updateCache`, update node into cache
  - Func `getBibFilePaths`, get paths of bib file given the root path
### `src/intellisense/texDocSymbolProvider.ts`
In this file, the `DocSymbolProvider` is extended to maintain a symbol cache with respect to different project by maintaining Map `projectCaches`.
The map will first require init if the root is not visited yet to provide a bib file list from the compiled project. The initilization consits of creating symbol cache from file. 
###  `src/intellisense/langIntellisenseProvider.ts`
In this file, the bibItem completion is now done by `getBibCompletionItemsFromBbl` and `getBibCompletionItemsFromBib` from `.bbl` and `.bib`, respectively.