### PR TITLE
[FIX] restrict pdf viewer actiation scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -667,13 +667,7 @@
         "displayName": "%customEditors.overleaf-workshop.pdfViewer.displayName%",
         "selector": [
           {
-            "filenamePattern": "**/output.pdf"
-          },
-          {
-            "filenamePattern": "*.pdf"
-          },
-          {
-            "filenamePattern": "*.PDF"
+            "filenamePattern": "overleaf-workshop:/**/{*.pdf, .PDF}"
           }
         ],
         "priority": "default"


### PR DESCRIPTION
> resolves #97 

Only use PDF viewer for URI with `overleaf-workshop` scheme.