### PR TITLE
[FIX]: autocompletion completion for command beginwith or endwith cite

### DIFF
--- a/src/intellisense/langCompletionProvider.ts
+++ b/src/intellisense/langCompletionProvider.ts
@@ -367,7 +367,7 @@ export class ReferenceCompletionProvider extends IntellisenseProvider implements
         // group 0: reference
         ['\\w*ref'],
         // group 1: citation
-        ['cite'],
+        ['cite\\w*', '\\w*cite'],
     ];
 
     constructor(vfsm: RemoteFileSystemProvider, private readonly texSymbolProvider: TexDocumentSymbolProvider) {


### PR DESCRIPTION
> resolve #165 

Make cite completion triggered by command beginwith or endwith `cite` 