### PR TITLE
[Fix] Fix PDF not updated when drag PDF to new window. Change strategy when sync code

### DIFF
--- a/src/compile/compileManager.ts
+++ b/src/compile/compileManager.ts
@@ -291,6 +291,36 @@ export class CompileManager {
         }
     }
 
+    private _revealSelectionInEditor(editor: vscode.TextEditor, targetLine: number, identifier: string) {
+        const _identifier = identifier.replace(/\s+/g, '\\s+');
+        // targetLine is 1-based from the syncTeX result
+        const lineIndex = targetLine - 1;
+
+        if (lineIndex < 0 || lineIndex >= editor.document.lineCount) {
+            console.warn(`${ELEGANT_NAME}: Invalid line number ${targetLine} for revealing in editor. Document has ${editor.document.lineCount} lines.`);
+            // Optionally, just focus the editor if the line is invalid
+            vscode.window.showTextDocument(editor.document, { viewColumn: editor.viewColumn, preserveFocus: false });
+            return;
+        }
+
+        const lineText = editor.document.lineAt(lineIndex).text;
+        const match = lineText.match(_identifier);
+        const matchIndex = match?.index ?? 0;
+
+        let newSelections: vscode.Selection[];
+        const newSelection = new vscode.Selection(lineIndex, matchIndex, lineIndex, matchIndex);
+        if (editor.selections.length > 0) {
+            newSelections = editor.selections.map((sel, index) =>
+                index === 0 ? newSelection : sel
+            );
+        } else {
+            newSelections = [newSelection];
+        }
+        editor.selections = newSelections;
+
+        editor.revealRange(new vscode.Range(lineIndex, matchIndex, lineIndex, matchIndex), vscode.TextEditorRevealType.InCenter);
+    }
+
     async syncPdf(r: { page: number, h: number, v: number, identifier: string }) {
         const uri = await CompileManager.check();
         if (uri) {
@@ -302,25 +332,33 @@ export class CompileManager {
                         const { file, line, column } = res;
                         const _file = file.match(/output\.[^\.]+$/) ? `${OUTPUT_FOLDER_NAME}/${file}` : file;
                         const fileUri = uri.with({ path: `/${projectName}/${_file}` });
-                        // get doc by fileUri
-                        const viewColumn = vscode.window.visibleTextEditors.at(-1)?.viewColumn || vscode.ViewColumn.Beside;
-                        vscode.commands.executeCommand('vscode.open', fileUri, { viewColumn })
-                            .then((doc) => {
-                                for (const editor of vscode.window.visibleTextEditors) {
-                                    if (editor.document.uri.toString() === fileUri.toString()) {
-                                        const _identifier = r.identifier.replace(/\s+/g, '\\s+');
-                                        const matchIndex = editor.document.lineAt(line - 1).text.match(_identifier)?.index || 0;
-                                        editor.selections = editor.selections.map((sel, index) => {
-                                            return index === 0 ?
-                                                new vscode.Selection(line - 1, matchIndex, line - 1, matchIndex)
-                                                : sel;
-                                        });
-                                        editor.revealRange(new vscode.Range(line - 1, matchIndex, line - 1, matchIndex), vscode.TextEditorRevealType.InCenter);
-                                        break;
+
+                        let viewColumnToUse: vscode.ViewColumn | undefined;
+                        const existingEditor = vscode.window.visibleTextEditors.find(
+                            e => e.document.uri.toString() === fileUri.toString()
+                        );
+
+                        if (existingEditor) {
+                            viewColumnToUse = existingEditor.viewColumn;
+                        } else {
+                            viewColumnToUse = vscode.window.visibleTextEditors.at(-1)?.viewColumn || vscode.ViewColumn.Beside;
+                        }
+
+                        vscode.window.showTextDocument(fileUri, { viewColumn: viewColumnToUse, preserveFocus: false })
+                            .then(
+                                (openedEditor) => {
+                                    if (openedEditor) {
+                                        this._revealSelectionInEditor(openedEditor, line, r.identifier);
                                     }
+                                },
+                                (error) => {
+                                    console.error(`${ELEGANT_NAME}: Failed to open document ${fileUri.fsPath} for syncPdf:`, error);
                                 }
-                            });
+                            );
                     }
+                })
+                .catch(error => {
+                    console.error(`${ELEGANT_NAME}: Error in syncPdf promise chain:`, error);
                 });
         }
     }

--- a/src/core/pdfViewEditorProvider.ts
+++ b/src/core/pdfViewEditorProvider.ts
@@ -65,8 +65,12 @@ export class PdfViewEditorProvider implements vscode.CustomEditorProvider<PdfDoc
 
     public async resolveCustomEditor(doc: PdfDocument, webviewPanel: vscode.WebviewPanel): Promise<void> {
         EventBus.fire('pdfWillOpenEvent', {uri: doc.uri, doc, webviewPanel});
-        doc.onDidChange(() => {
+        const docOnDidChangeListener = doc.onDidChange(() => {
             this.updateWebview(doc, webviewPanel);
+        });
+
+        webviewPanel.onDidDispose(() => {
+            docOnDidChangeListener.dispose();
         });
 
         webviewPanel.webview.options = {enableScripts:true};

--- a/src/core/pdfViewEditorProvider.ts
+++ b/src/core/pdfViewEditorProvider.ts
@@ -75,7 +75,6 @@ export class PdfViewEditorProvider implements vscode.CustomEditorProvider<PdfDoc
 
         webviewPanel.webview.options = {enableScripts:true};
         webviewPanel.webview.html = await this.getHtmlForWebview(webviewPanel.webview);
-        updateWebview();
 
         // register event listeners
         webviewPanel.onDidChangeViewState((e) => {

--- a/src/intellisense/langMisspellingCheckProvider.ts
+++ b/src/intellisense/langMisspellingCheckProvider.ts
@@ -105,6 +105,10 @@ export class MisspellingCheckProvider extends IntellisenseProvider implements vs
     }
 
     provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeAction[]> {
+        if (context.diagnostics.length === 0) {
+            return [];
+        }
+
         const diagnostic = context.diagnostics[0];
         const actions = this.suggestionCache.get(diagnostic.code as string)
                         ?.slice(0,8).map(suggestion => {


### PR DESCRIPTION
- Fix PDF not updated when drag PDF to new window
  - When we drag a PDF tab to a new window by https://code.visualstudio.com/docs/getstarted/userinterface#_floating-windows , the webview will reload, and the content inside it is not retained. So although it is declared as `retainContextWhenHidden` https://github.com/iamhyc/Overleaf-Workshop/blob/master/src/core/pdfViewEditorProvider.ts#L97-L99 , it does not apply to the situation when we drag it to new window.
  - So it is a full reload for webview, and we would better send the pdf content to it when it is ready (again). Because the doc has not changed (Same code, same pdf), it will not trigger event to update the pdf into webview. 
  - At the first time of pdf is ready, the conent is empty, so https://github.com/iamhyc/Overleaf-Workshop/pull/270/files#diff-4efc4ac13fed7e6ee8519675a797c6ca2eeea99224f8becdf7f88e80105b09ebR60-R62 will block it.
- Directly return empty array when context.diagnostics.length === 0
  - Avoid access `[0]`https://github.com/iamhyc/Overleaf-Workshop/pull/270/files#diff-64b94b3e8ddabe5815d5f7f599f2fcb49785d2a4434fed967de3f36e9c28f62bL108 when is it empty, which will result a exception in the console log
- Dispose the listener to avoid error `Webview is disposed`
  - The callback for `doc.onDidChange` is still alive when the webview is disposed, resulting https://github.com/iamhyc/Overleaf-Workshop/pull/270/files#diff-4efc4ac13fed7e6ee8519675a797c6ca2eeea99224f8becdf7f88e80105b09ebL62 an invalid postMessage

![image](https://github.com/user-attachments/assets/58e71c12-afb6-4c90-ae1a-75f22b9189df)

- Change sync code strategy
  - First, it will try to find the first editor with the desired tex opened, if found, it will show it instead of use the latest `visibleTextEditors`
  - Then it will reveal the opened editor instead of the first one `visibleTextEditors`
  - The current strategy is that it will always use the last visible text editor's viewColumns. If there is a floating window, and there is unrelated editor (such as opened file is not the target file), the last one of `visibleTextEditors` will be it. And the tex will be opened at the float window, creating a new tab.
  - I have changed it to prioritize reuse the available opened tex file to show the synced code location