### PR TITLE
[Feature]: Enable Code Spell Checker by Default

### DIFF
--- a/src/intellisense/langIntellisenseProvider.ts
+++ b/src/intellisense/langIntellisenseProvider.ts
@@ -28,6 +28,12 @@ export class LangIntellisenseProvider {
             new MisspellingCheckProvider(vfsm),
         ];
         this.status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -2);
+        // Enable CSpell
+        const config = vscode.workspace.getConfiguration("cSpell");
+        const enabledSchemes = config.get<Record<string, boolean>>("enabledSchemes") || {}; 
+        enabledSchemes[ROOT_NAME] = true; 
+        config.update("enabledSchemes", enabledSchemes, vscode.ConfigurationTarget.Global);
+        
         this.activate();
     }
 


### PR DESCRIPTION
> resolve #262 

The Code Spell Checker is automatically enabled when the overleaf-workshop extension activates. 
Configuration modifications occur during the IntelliSense provider initialization globally (since the workspace setting would be automatically synced with remote server and currently no filter in online mode is available).

The performance is verified under:
+ [x] official overleaf server
+ [x] community overleaf server (the spell checker in overleaf-workshop would be first place)
+ [x] local replica

**Note:** If the Code Spell Checker extension is not installed, this approach gracefully skips configuration due to VS Code's built-in API logic.  
