### PR TITLE
Potential fix for code scanning alert no. 1: Client-side cross-site scripting

### DIFF
--- a/views/pdf-viewer/index.js
+++ b/views/pdf-viewer/index.js
@@ -68,6 +68,11 @@
         ColorThemes = themes;
         // set global css
         const style = document.createElement('style');
+        document.head.appendChild(style);
+        if (!style.sheet) {
+            console.error('Failed to initialize stylesheet for color themes.');
+            return;
+        }
         for (const theme in ColorThemes) {
             // sanitize theme name
             if (theme.match(/^[a-zA-Z0-9-_]+$/) === null) {
@@ -81,11 +86,8 @@
                 continue;
             }
             // update css
-            style.innerHTML += `
-                #theme-${theme}::before {
-                    background-color: ${ColorThemes[theme].bgColor};
-                }
-            `;
+            const rule = `#theme-${theme}::before { background-color: ${ColorThemes[theme].bgColor}; }`;
+            style.sheet.insertRule(rule, style.sheet.cssRules.length);
         }
         document.head.appendChild(style);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/1](https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/1)

To fix the issue, we will replace the use of `innerHTML` with a safer alternative. Instead of concatenating strings and injecting them into the DOM, we will use the `CSSStyleSheet` API or `textContent` to safely add CSS rules. This approach avoids the risks associated with `innerHTML` while preserving the intended functionality.

Specifically:
1. Replace the `style.innerHTML` assignment with a loop that uses `style.sheet.insertRule` to add CSS rules programmatically.
2. Ensure that the sanitization logic remains intact to validate theme names and color values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
