### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vsce-package.yml
+++ b/.github/workflows/vsce-package.yml
@@ -1,4 +1,7 @@
 name: Package Extension
+permissions:
+  contents: read
+  packages: write
 on:
   pull_request:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/3](https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for uploading the artifact.

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
