### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vsce-publish.yml
+++ b/.github/workflows/vsce-publish.yml
@@ -1,4 +1,6 @@
 name: Publish Extension
+permissions:
+  contents: read
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/2](https://github.com/iamhyc/Overleaf-Workshop/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily involves reading repository contents and publishing an extension, the `contents: read` permission is sufficient. This block can be added at the root level of the workflow to apply to all jobs or within the specific job (`publish`) to limit permissions for that job only.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow or within the `publish` job.
2. Setting `contents: read` as the permission, which is the least privilege required for the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
