### PR TITLE
fix: file rename

### DIFF
--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -854,8 +854,8 @@ export class VirtualFileSystem extends vscode.Disposable {
             if (res?.type==='success') {
                 const newEntity = Object.assign(oldPath.fileEntity);
                 newEntity.name = newPath.fileName;
-                this.insertEntity(newPath.parentFolder, oldPath.fileType, newEntity);
                 this.removeEntity(oldPath.parentFolder, oldPath.fileType, oldPath.fileEntity);
+                this.insertEntity(newPath.parentFolder, oldPath.fileType, newEntity);
                 this.notify([
                     {type: vscode.FileChangeType.Deleted, uri: oldUri},
                     {type: vscode.FileChangeType.Created, uri: newUri},


### PR DESCRIPTION
`removeEntity()` and `insertEntity()` both operate based on the `FileEntity._id`. If we rename a file, its `_id` stays the same. We must remove first and then insert. Otherwise the insert doesn't do anything and the file just gets removed.

This fixes #289