### PR TITLE
fix: mark isViewerEmbedded as true for pdfviewer to avoid unnecessary focus change

### DIFF
--- a/views/pdf-viewer/index.js
+++ b/views/pdf-viewer/index.js
@@ -130,6 +130,7 @@
         } else {
             backupPdfViewerState();
         }
+        PDFViewerApplication.isViewerEmbedded = true;
         PDFViewerApplication.load(doc);
     }
 


### PR DESCRIPTION
fix https://github.com/iamhyc/Overleaf-Workshop/issues/294

this bypass the pdfViewer.focus(); in the `.load` function of PDFViewerApplication

<img width="423" height="249" alt="image" src="https://github.com/user-attachments/assets/482e17b5-2e9b-4aac-a2b7-d4ce00d2d045" />
