### PR TITLE
rename repo name & complete auto-publish workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,8 +9,8 @@ assignees: ''
 
 ### Disclaimer
 > Please make sure all the items below is checked (i.e., prefixed with "- [x]")
-- [ ] The request feature has not been addressed in the [feature request list](https://github.com/iamhyc/Overleaf-Workshop/issues?q=is%3Aissue+label%3A%22feature+request%22+).
-- [ ] The design of the feature does not require detailed discussion, or existing discussion with drawn conclusion can be found in [Discussions Area](https://github.com/iamhyc/Overleaf-Workshop/discussions) at: [paste the link here]
+- [ ] The request feature has not been addressed in the [feature request list](https://github.com/overleaf-workshop/Overleaf-Workshop/issues?q=is%3Aissue+label%3A%22feature+request%22+).
+- [ ] The design of the feature does not require detailed discussion, or existing discussion with drawn conclusion can be found in [Discussions Area](https://github.com/overleaf-workshop/Overleaf-Workshop/discussions) at: [paste the link here]
 
 ### Motivation
 > Please give strong enough reason(s) why the feature is demanded.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,7 +77,7 @@ This code of conduct and its related procedures also applies to unacceptable beh
 
 ## 10. Contact info
 
-[iamhyc](mailto:sudofree__at__163_com)
+[iamhyc](mailto:ychong__at__petalmail_com)
 
 ## 11. License and attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ In this document, we will mainly elaborate on how to make code contributions to 
 
 > [!WARNING]
 > We will not accept any pull request that is not associated with an issue.
-> If you have any question about the project, please create an issue or discuss it in the [Discussions](https://github.com/iamhyc/Overleaf-Workshop/discussions) section.
+> If you have any question about the project, please create an issue or discuss it in the [Discussions](https://github.com/overleaf-workshop/Overleaf-Workshop/discussions) section.
 
 To make a contribution to this project, please follow the steps below:
 
-1. Create or find an `Bug Report` or `Feature Request` issue on [GitHub](https://github.com/iamhyc/Overleaf-Workshop/issues).
+1. Create or find an `Bug Report` or `Feature Request` issue on [GitHub](https://github.com/overleaf-workshop/Overleaf-Workshop/issues).
    
    If you are creating a new issue, please make sure that it is not a duplicate of an existing issue.
 
@@ -49,7 +49,7 @@ To make a contribution to this project, please follow the steps below:
 
 ```bash
 # Clone the Repository and Change Directory
-git clone https://github.com/iamhyc/Overleaf-Workshop.git
+git clone https://github.com/overleaf-workshop/Overleaf-Workshop.git
 cd Overleaf-Workshop
 
 # Install `vsce` globally
@@ -71,4 +71,4 @@ In VSCode, press <kbd>F5</kbd> to start debugging. A new VSCode window will be o
 
 ### Documentation
 - [VSCode Extension API](https://code.visualstudio.com/api/references/vscode-api)
-- [Overleaf Workshop Extension Documentation](https://github.com/iamhyc/Overleaf-Workshop/tree/master/docs/README.md)
+- [Overleaf Workshop Extension Documentation](https://github.com/overleaf-workshop/Overleaf-Workshop/tree/master/docs/README.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overleaf Workshop
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/iamhyc/Overleaf-Workshop)](https://github.com/iamhyc/Overleaf-Workshop)
+[![GitHub Repo stars](https://img.shields.io/github/stars/overleaf-workshop/Overleaf-Workshop)](https://github.com/overleaf-workshop/Overleaf-Workshop)
 [![version](https://img.shields.io/visual-studio-marketplace/v/iamhyc.overleaf-workshop)](https://marketplace.visualstudio.com/items?itemName=iamhyc.overleaf-workshop)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/iamhyc.overleaf-workshop)](https://marketplace.visualstudio.com/items?itemName=iamhyc.overleaf-workshop)
 [![updated](https://img.shields.io/visual-studio-marketplace/last-updated/iamhyc.overleaf-workshop)](https://marketplace.visualstudio.com/items?itemName=iamhyc.overleaf-workshop)
@@ -10,7 +10,7 @@ Open Overleaf (ShareLatex) projects in VSCode, with full collaboration support.
 
 ### User Guide
 
-The full user guide is available at [GitHub Wiki](https://github.com/iamhyc/Overleaf-Workshop/wiki).
+The full user guide is available at [GitHub Wiki](https://github.com/overleaf-workshop/Overleaf-Workshop/wiki).
 
 ### Features
 
@@ -20,12 +20,12 @@ The full user guide is available at [GitHub Wiki](https://github.com/iamhyc/Over
 
 - Login Server, Open Projects and Edit Files
 
-    <img src="https://raw.githubusercontent.com/iamhyc/Overleaf-Workshop/master/docs/assets/demo01-login.gif" height=400px/>
+    <img src="https://raw.githubusercontent.com/overleaf-workshop/Overleaf-Workshop/master/docs/assets/demo01-login.gif" height=400px/>
 
 - On-the-fly Compiling and Previewing
   > <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>B</kbd> to compile, <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>V</kbd> preview.
 
-    <img src="https://raw.githubusercontent.com/iamhyc/Overleaf-Workshop/master/docs/assets/demo03-synctex.gif" height=400px/>
+    <img src="https://raw.githubusercontent.com/overleaf-workshop/Overleaf-Workshop/master/docs/assets/demo03-synctex.gif" height=400px/>
 
 - SyncTeX and Reverse SyncTeX
   > <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> to jump to PDF.
@@ -33,15 +33,15 @@ The full user guide is available at [GitHub Wiki](https://github.com/iamhyc/Over
 
 - Chat with Collaborators
 
-    <img src="https://raw.githubusercontent.com/iamhyc/Overleaf-Workshop/master/docs/assets/demo06-chat.gif" height=400px/>
+    <img src="https://raw.githubusercontent.com/overleaf-workshop/Overleaf-Workshop/master/docs/assets/demo06-chat.gif" height=400px/>
 
 - Open Project Locally, Compile/Preview with [LaTeX-Workshop](https://github.com/James-Yu/LaTeX-Workshop)
 
-    <img src="https://raw.githubusercontent.com/iamhyc/Overleaf-Workshop/master/docs/assets/demo07-local.gif" height=400px/>
+    <img src="https://raw.githubusercontent.com/overleaf-workshop/Overleaf-Workshop/master/docs/assets/demo07-local.gif" height=400px/>
 
 ### How to Login with Cookies
 
-<img src="https://raw.githubusercontent.com/iamhyc/Overleaf-Workshop/master/docs/assets/login_with_cookie.png" height=400px/>
+<img src="https://raw.githubusercontent.com/overleaf-workshop/Overleaf-Workshop/master/docs/assets/login_with_cookie.png" height=400px/>
 
 In an already logged-in browser (Firefox for example):
 

--- a/docs/anatomy.md
+++ b/docs/anatomy.md
@@ -117,7 +117,7 @@ The exported `class ExtendedBaseAPI` extends the `class BaseAPI` with extra feat
 The implementation of `socket.io-client`-based websocket API used by overleaf server.
 The implementation is carried out by observation of raw websocket messages via browser developer tools, and is loosely coupled with the extension for reuse in other projects.
 
-There are currently two versions of `socketio` API is supported:`v1` for relative old versions, `v2` for `overleaf.com` (maybe a newer version, mentioned in [this issue](https://github.com/iamhyc/Overleaf-Workshop/issues/42)).
+There are currently two versions of `socketio` API is supported:`v1` for relative old versions, `v2` for `overleaf.com` (maybe a newer version, mentioned in [this issue](https://github.com/overleaf-workshop/Overleaf-Workshop/issues/42)).
 The only difference exists in the handshake phase: whether the `projectId` parameter should be passed.
 
 **Interfaces**
@@ -170,7 +170,7 @@ The standalone module for online users and chat message functions.
 
 #### `src/collaboration/clientManager.ts`
 The export `class ClientManager` exposes features to vscode via `(get) triggers` with:
-> Notice that it ties to `this.socket.updateEventHandlers` in its constructor, which may cause memory leak even when all triggers are disposed ([related issue #51](https://github.com/iamhyc/Overleaf-Workshop/issues/51))
+> Notice that it ties to `this.socket.updateEventHandlers` in its constructor, which may cause memory leak even when all triggers are disposed ([related issue #51](https://github.com/overleaf-workshop/Overleaf-Workshop/issues/51))
 - **StatusBarItem**
   - **Tooltip**: hover the item displays the client connection status, online user status (inactive time, cursor position) periodically (500ms) refreshed in `this.updateStatus` function.
   - **Settings**: click the item to display project-dependent settings defined in `this.collaborationSettings`

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -141,7 +141,7 @@ However, due to the [limitation of the virtual workspace](https://github.com/mic
 > [!NOTE]
 > The Overleaf features are not completely enabled in a local folder. Specifically, the [compile](#compile-project), [PDF preview](#preview-document), [intellisense](#intellisense) and [project history](#history-of-changes) features are disabled by default.
 > 
-> Currently, there is no way to enable these features in a local folder, especially considering people would like to use the LaTeX Workshop extension in a local folder. If you are in demand of these features, please consider to create a discussion in the [GitHub Discussions](https://github.com/iamhyc/Overleaf-Workshop/discussions)
+> Currently, there is no way to enable these features in a local folder, especially considering people would like to use the LaTeX Workshop extension in a local folder. If you are in demand of these features, please consider to create a discussion in the [GitHub Discussions](https://github.com/overleaf-workshop/Overleaf-Workshop/discussions)
 
 The "Open Project Locally" feature is provided via a [local replica](#local-replica). The local replica is a folder on your local machine with a `.overleaf` folder presence, which is kept in sync with the project on the Overleaf server.
 
@@ -374,7 +374,7 @@ The available commands and default shortcuts can be found in the command palette
 - **"Set Compiler"**: This command is used to change the compiler of the current project.
 - **"Set Root Document"**: This command is used to change the root document to be compiled of the current project.
 
-Let us know if you have any suggestions for the commands and shortcuts in the [GitHub Discussions](https://github.com/iamhyc/Overleaf-Workshop/discussions).
+Let us know if you have any suggestions for the commands and shortcuts in the [GitHub Discussions](https://github.com/overleaf-workshop/Overleaf-Workshop/discussions).
 
 ### Configurations
 
@@ -425,4 +425,4 @@ Please notice that not all Overleaf features enabled in a local folder. More spe
 - Enable/Disable the network proxy for VS Code (or the Overleaf server domain) globally.
 - Try [Invisible Mode](#invisible-mode), which does not use WebSocket to communicate with the server.
 
-If the above solutions do not work, please consider to create a bug report in the [GitHub Issues](https://github.com/iamhyc/Overleaf-Workshop/issues/new/choose).
+If the above solutions do not work, please consider to create a bug report in the [GitHub Issues](https://github.com/overleaf-workshop/Overleaf-Workshop/issues/new/choose).

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -54,7 +54,7 @@
   "Password": "Password",
   "Login failed.": "Login failed.",
   "Cookies, e.g., \"sharelatex.sid=...\" or \"overleaf_session2=...\"": "Cookies, e.g., \"sharelatex.sid=...\" or \"overleaf_session2=...\"",
-  "README: [How to Login with Cookies](https://github.com/iamhyc/overleaf-workshop#how-to-login-with-cookies)": "README: [How to Login with Cookies](https://github.com/iamhyc/overleaf-workshop#how-to-login-with-cookies)",
+  "README: [How to Login with Cookies](https://github.com/overleaf-workshop/overleaf-workshop#how-to-login-with-cookies)": "README: [How to Login with Cookies](https://github.com/overleaf-workshop/overleaf-workshop#how-to-login-with-cookies)",
   "Select the login method below.": "Select the login method below.",
   "Logout server \"{name}\" ?": "Logout server \"{name}\" ?",
   "Blank Project": "Blank Project",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/iamhyc/overleaf-workshop"
+    "url": "https://github.com/overleaf-workshop/overleaf-workshop"
   },
   "bugs": {
-    "url": "https://github.com/iamhyc/overleaf-workshop/issues"
+    "url": "https://github.com/overleaf-workshop/overleaf-workshop/issues"
   },
   "engines": {
     "vscode": "^1.80.0"

--- a/src/core/projectManagerProvider.ts
+++ b/src/core/projectManagerProvider.ts
@@ -235,7 +235,7 @@ export class ProjectManagerProvider implements vscode.TreeDataProvider<DataItem>
             'Login with Cookies': () => {
                 vscode.window.showInputBox({
                     'placeHolder': vscode.l10n.t('Cookies, e.g., "sharelatex.sid=..." or "overleaf_session2=..."'),
-                    'prompt': vscode.l10n.t('README: [How to Login with Cookies](https://github.com/iamhyc/overleaf-workshop#how-to-login-with-cookies)'),
+                    'prompt': vscode.l10n.t('README: [How to Login with Cookies](https://github.com/overleaf-workshop/overleaf-workshop#how-to-login-with-cookies)'),
                 })
                 .then(cookies => cookies ? Promise.resolve(cookies) : Promise.reject())
                 .then(cookies =>

--- a/src/intellisense/texDocumentSymbolProvider.ts
+++ b/src/intellisense/texDocumentSymbolProvider.ts
@@ -58,7 +58,7 @@ function elementsToFoldingRanges(sections: TeXElement[]): vscode.FoldingRange[] 
     return foldingRanges;
 }
 
-// Reference: https://github.com/iamhyc/LaTeX-Workshop/commit/d1a078d9b63a34c9cda9ff5d1042c8999030e6e1
+// Reference: https://github.com/James-Yu/LaTeX-Workshop/commit/d1a078d9b63a34c9cda9ff5d1042c8999030e6e1
 function getEnvironmentFoldingRange(document: vscode.TextDocument){
     const ranges: vscode.FoldingRange[] = [];
     const opStack: { keyword: string, index: number }[] = [];


### PR DESCRIPTION
This PR intends to:

- [x] rename the repo owner from `iamhyc` to `overleaf-workshop`
- [x] add auto publish procedure to [open vsx registry](https://open-vsx.org/)
- [x] determine when to trigger the publish procedure (e.g., when version bumps)