### PR TITLE
Fix outputBuildId extraction logic

### DIFF
--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -915,7 +915,7 @@ export class VirtualFileSystem extends vscode.Disposable {
         if (this.root) {
             // update output buildId
             // '/project/65dbfff719ad65b54b9eaed4/user/65094b5fa537faaba0bec01f/build/19620231e54-5372f67292889500/output/output.aux' --> 19620231e54-5372f67292889500'
-            this.outputBuildId = outputs[0].url.split('/').slice(6)[0];
+            this.outputBuildId = outputs[0].url.match(/\/build\/([^\/]+)/)?.[1];
 
             const rootFolder = this.root.rootFolder[0];
             if (this.removeEntityById(rootFolder, 'folder', __OUTPUTS_ID)) {


### PR DESCRIPTION
Currently `outputBuildId` is extracted reversely using a negative index -3. However, sometimes this can go wrong. For example, I'm using `minted` and may get something like `/project/xxx/user/xxx/build/xxxx/output/_minted/xxx`. In this case, `output` is extracted, which is not expected.

This PR extracts `outputBuildId` using a positive index 6 to avoid the above issue.

This might be related with #297, because I also got the error code 500 before applying the fix.