### PR TITLE
feat(local-replica): ignore latexindent temporary filenames by default 

### DIFF
--- a/src/scm/localReplicaSCM.ts
+++ b/src/scm/localReplicaSCM.ts
@@ -44,6 +44,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
         '**/.*',
         '**/.*/**',
         '**/*.aux',
+        '**/__latexindent*',
         '**/*.bbl',
         '**/*.bcf',
         '**/*.blg',


### PR DESCRIPTION
Add latexindent temporary filenames to default sync ignore patterns for local replicas.