### PR TITLE
fix: improve error handling and logging for local replica sync

### DIFF
--- a/src/core/projectManagerProvider.ts
+++ b/src/core/projectManagerProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ROOT_NAME } from '../consts';
 import { ProjectTagsResponseSchema } from '../api/base';
 import { GlobalStateManager } from '../utils/globalStateManager';
+import { Logger } from '../utils/logger';
 import { VirtualFileSystem, parseUri } from './remoteFileSystemProvider';
 import { LocalReplicaSCMProvider } from '../scm/localReplicaSCM';
 
@@ -567,6 +568,7 @@ export class ProjectManagerProvider implements vscode.TreeDataProvider<DataItem>
     }
 
     async openProjectLocalReplica(project: ProjectItem) {
+        Logger.info(`openProjectLocalReplica: starting for project "${project.label}"`);
         // should close other open vfs firstly
         const vfsFolder = vscode.workspace.workspaceFolders?.find(folder => folder.uri.scheme===ROOT_NAME);
         if (vfsFolder) {
@@ -582,7 +584,9 @@ export class ProjectManagerProvider implements vscode.TreeDataProvider<DataItem>
         // if not exist, create new one
         if (replicas.length===0) {
             const vfs = (await (await vscode.commands.executeCommand('remoteFileSystem.prefetch', uri))) as VirtualFileSystem;
+            Logger.info(`openProjectLocalReplica: VFS prefetched for ${uri.toString()}`);
             await vfs.init();
+            Logger.info(`openProjectLocalReplica: VFS initialized`);
             const answer = await vscode.window.showWarningMessage( vscode.l10n.t('No local replica found, create one for project "{label}" ?', {label:project.label}), "Yes", "No");
             if (answer === "Yes") {
                 await (await vscode.commands.executeCommand(`${ROOT_NAME}.projectSCM.newSCM`, LocalReplicaSCMProvider));
@@ -623,7 +627,8 @@ export class ProjectManagerProvider implements vscode.TreeDataProvider<DataItem>
                             const scmKey = Object.keys(scmPersists).find(key => vscode.Uri.parse(scmPersists[key].baseUri).fsPath===item.label)!;
                             GlobalStateManager.updateServerProjectSCMPersist(this.context, serverName, projectId, scmKey);
                             // remove entry from quick pick
-                            quickPick.items = quickPick.items.filter(item => item.label!==item.label);
+                            const removedLabel = item.label;
+                            quickPick.items = quickPick.items.filter(qpItem => qpItem.label!==removedLabel);
                         }
                     });
                 }
@@ -638,6 +643,7 @@ export class ProjectManagerProvider implements vscode.TreeDataProvider<DataItem>
             quickPick.show();
         })
         .then(path => {
+            Logger.info(`openProjectLocalReplica: opening local folder ${path}`);
             const uri = vscode.Uri.file(path as string);
             // always open in current window
             vscode.commands.executeCommand('vscode.openFolder', uri, false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,8 +7,13 @@ import { PdfViewEditorProvider } from './core/pdfViewEditorProvider';
 import { CompileManager } from './compile/compileManager';
 import { LangIntellisenseProvider } from './intellisense';
 import { LocalReplicaSCMProvider } from './scm/localReplicaSCM';
+import { Logger } from './utils/logger';
 
 export function activate(context: vscode.ExtensionContext) {
+    // Initialize logger - must be first
+    context.subscriptions.push(Logger.init());
+    Logger.info('Overleaf Workshop activating');
+
     // Register: [core] RemoteFileSystemProvider
     const remoteFileSystemProvider = new RemoteFileSystemProvider(context);
     context.subscriptions.push( ...remoteFileSystemProvider.triggers );
@@ -36,6 +41,7 @@ export function activate(context: vscode.ExtensionContext) {
             const uri = vscode.Uri.parse(setting.uri);
             if (uri.scheme===ROOT_NAME) {
                 // activate vfs
+                Logger.info(`Activating local replica VFS for: ${uri.toString()}`);
                 const vfs = (await (await vscode.commands.executeCommand('remoteFileSystem.prefetch', uri))) as VirtualFileSystem;
                 await vfs.init();
                 vscode.commands.executeCommand('setContext', `${ROOT_NAME}.activate`, true);

--- a/src/scm/localReplicaSCM.ts
+++ b/src/scm/localReplicaSCM.ts
@@ -3,6 +3,7 @@ import * as DiffMatchPatch from 'diff-match-patch';
 import { minimatch } from 'minimatch';
 import { BaseSCM, CommitItem, SettingItem } from ".";
 import { VirtualFileSystem, parseUri } from '../core/remoteFileSystemProvider';
+import { Logger } from '../utils/logger';
 
 const IGNORE_SETTING_KEY = 'ignore-patterns';
 
@@ -97,14 +98,16 @@ export class LocalReplicaSCMProvider extends BaseSCM {
             try {
                 const stat = await vscode.workspace.fs.stat(baseUri);
                 if (stat.type!==vscode.FileType.Directory) {
-                    throw new Error('Not a folder');
-                }
-                // check if the project name is included in the path
-                if (folderName!==undefined && !baseUri.path.endsWith(`/${folderName}`)) {
-                    baseUri = vscode.Uri.joinPath(baseUri, folderName);
+                    Logger.warn(`validateBaseUri: path exists but is not a directory: ${baseUri.fsPath}`);
+                } else {
+                    // check if the project name is included in the path
+                    if (folderName!==undefined && !baseUri.path.endsWith(`/${folderName}`)) {
+                        baseUri = vscode.Uri.joinPath(baseUri, folderName);
+                    }
                 }
             } catch {
-                // keep the baseUri as is
+                // Path does not exist yet - createDirectory below will handle it
+                Logger.info(`validateBaseUri: path does not exist yet, will create: ${baseUri.fsPath}`);
             }
             // try to create the folder with `mkdirp` semantics
             await vscode.workspace.fs.createDirectory(baseUri);
@@ -236,35 +239,47 @@ export class LocalReplicaSCMProvider extends BaseSCM {
 
             // sync the files
             const total = files.length;
+            const failedFiles: string[] = [];
             for (let i=0; i<total; i++) {
                 const [name, relPath] = files[i];
                 const vfsUri = this.vfs.pathToUri(relPath);
                 if (token.isCancellationRequested) { return false; }
                 progress.report({increment: 100/total, message: relPath});
-                //
-                const baseContent = this.baseCache[relPath];
-                const localContent = await this.readFile(relPath);
-                const remoteContent = await vscode.workspace.fs.readFile(vfsUri);
-                if (baseContent===undefined || localContent===undefined) {
-                    this.setBypassCache(relPath, remoteContent);
-                    await this.writeFile(relPath, remoteContent);
-                } else {
-                    const dmp = new DiffMatchPatch();
-                    const baseContentStr = new TextDecoder().decode(baseContent);
-                    const localContentStr = new TextDecoder().decode(localContent);
-                    const remoteContentStr = new TextDecoder().decode(remoteContent);
-                    // merge local and remote changes
-                    const localPatches = dmp.patch_make( baseContentStr, localContentStr );
-                    const remotePatches = dmp.patch_make( baseContentStr, remoteContentStr );
-                    const [mergedContentStr, _results] = dmp.patch_apply( remotePatches, localContentStr );
-                    // write the merged content to local
-                    const mergedContent = new TextEncoder().encode(mergedContentStr);
-                    await this.writeFile(relPath, mergedContent);
-                    // write the merged content to remote
-                    if (localPatches.length!==0) {
-                        await vscode.workspace.fs.writeFile(vfsUri, mergedContent);
+
+                try {
+                    const baseContent = this.baseCache[relPath];
+                    const localContent = await this.readFile(relPath);
+                    const remoteContent = await vscode.workspace.fs.readFile(vfsUri);
+                    if (baseContent===undefined || localContent===undefined) {
+                        this.setBypassCache(relPath, remoteContent);
+                        await this.writeFile(relPath, remoteContent);
+                    } else {
+                        const dmp = new DiffMatchPatch();
+                        const baseContentStr = new TextDecoder().decode(baseContent);
+                        const localContentStr = new TextDecoder().decode(localContent);
+                        const remoteContentStr = new TextDecoder().decode(remoteContent);
+                        // merge local and remote changes
+                        const localPatches = dmp.patch_make( baseContentStr, localContentStr );
+                        const remotePatches = dmp.patch_make( baseContentStr, remoteContentStr );
+                        const [mergedContentStr, _results] = dmp.patch_apply( remotePatches, localContentStr );
+                        // write the merged content to local
+                        const mergedContent = new TextEncoder().encode(mergedContentStr);
+                        await this.writeFile(relPath, mergedContent);
+                        // write the merged content to remote
+                        if (localPatches.length!==0) {
+                            await vscode.workspace.fs.writeFile(vfsUri, mergedContent);
+                        }
                     }
+                } catch (error) {
+                    failedFiles.push(relPath);
+                    Logger.error(`overwrite: failed to sync file "${relPath}"`, error);
                 }
+            }
+
+            if (failedFiles.length > 0) {
+                const msg = vscode.l10n.t('{count} file(s) failed to sync. See Output for details.', { count: failedFiles.length });
+                vscode.window.showWarningMessage(msg);
+                Logger.show();
             }
 
             return true;
@@ -281,7 +296,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
             return true;
         }
         // otherwise, log the synchronization
-        console.log(`${new Date().toLocaleString()} [${action}] ${type} "${relPath}"`);
+        Logger.info(`[${action}] ${type} "${relPath}"`);
         return false;
     }
 
@@ -309,7 +324,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
                         this.baseCache[relPath] = newContent;
                         if (action==='push') { await vscode.workspace.fs.readFile(toUri); } // update remote cache
                     } catch (error) {
-                        console.error(error);
+                        Logger.error(`applySync [${action}] ${type} "${relPath}" failed`, error);
                     }
                 }
                 else {
@@ -385,6 +400,7 @@ export class LocalReplicaSCMProvider extends BaseSCM {
                 const content = await vscode.workspace.fs.readFile(uri);
                 resolve(content);
             } catch (error) {
+                Logger.warn(`readFile failed for "${relPath}"`, error);
                 resolve(undefined);
             }
         });

--- a/src/scm/scmCollectionProvider.ts
+++ b/src/scm/scmCollectionProvider.ts
@@ -7,6 +7,7 @@ import { LocalGitBridgeSCMProvider } from './localGitBridgeSCM';
 import { HistoryViewProvider } from './historyViewProvider';
 import { GlobalStateManager } from '../utils/globalStateManager';
 import { EventBus } from '../utils/eventBus';
+import { Logger } from '../utils/logger';
 import { ROOT_NAME } from '../consts';
 
 const supportedSCMs = [
@@ -152,7 +153,9 @@ export class SCMCollectionProvider extends vscode.Disposable {
         } catch (error) {
             // permanently remove failed scm
             // this.vfs.setProjectSCMPersist(scm.scmKey, undefined);
-            vscode.window.showErrorMessage( vscode.l10n.t('"{scm}" creation failed.', {scm:scmProto.label}) );
+            const errMsg = error instanceof Error ? error.message : String(error);
+            Logger.error(`SCM creation failed for "${scmProto.label}" at ${baseUri.toString()}`, error);
+            vscode.window.showErrorMessage( vscode.l10n.t('"{scm}" creation failed: {msg}', {scm:scmProto.label, msg:errMsg}) );
             return undefined;
         }
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import { ELEGANT_NAME } from '../consts';
+
+let _channel: vscode.OutputChannel | undefined;
+
+export class Logger {
+    static init(): vscode.Disposable {
+        _channel = vscode.window.createOutputChannel(ELEGANT_NAME);
+        return _channel;
+    }
+
+    private static _log(level: string, message: string, error?: unknown): void {
+        if (!_channel) { return; }
+        const timestamp = new Date().toLocaleString();
+        _channel.appendLine(`[${timestamp}] [${level}] ${message}`);
+        if (error instanceof Error) {
+            _channel.appendLine(`  ${error.message}`);
+            if (error.stack) {
+                _channel.appendLine(`  ${error.stack}`);
+            }
+        } else if (error !== undefined) {
+            _channel.appendLine(`  ${String(error)}`);
+        }
+    }
+
+    static info(message: string): void {
+        Logger._log('INFO', message);
+    }
+
+    static warn(message: string, error?: unknown): void {
+        Logger._log('WARN', message, error);
+    }
+
+    static error(message: string, error?: unknown): void {
+        Logger._log('ERROR', message, error);
+    }
+
+    static show(): void {
+        _channel?.show(true);
+    }
+}


### PR DESCRIPTION
- Add dedicated Output Channel ("Overleaf Workshop") for visible logging
- Fix overwrite() to be resilient to individual file failures instead of aborting entire sync when one file fails
- Fix createSCM() to log and display actual error details instead of generic "creation failed" message
- Fix QuickPick filter bug in openProjectLocalReplica() where variable shadowing caused item.label!==item.label (always false)
- Add logging to validateBaseUri(), readFile(), applySync(), bypassSync() and openProjectLocalReplica() for better diagnostics