### PR TITLE
feat: add editable settings for pdf viewer

### DIFF
--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -395,6 +395,8 @@ The project-irrelevant configurations of the extension can be found in the VS Co
         "dark":    {"fontColor":"#FBF0D9", "bgColor":"#4B4B4B"}
     }
     ```
+- **PDF Viewer: Default Scroll Mode**: This configuration controls the default scroll mode for the PDF viewer when there is no saved viewer state for the PDF. Allowed values are `vertical`, `horizontal`, `wrapped`, and `page`. The default value is `vertical`.
+- **PDF Viewer: Default Spread Mode**: This configuration controls the default spread mode for the PDF viewer when there is no saved viewer state for the PDF. Allowed values are `none`, `odd`, and `even`. The default value is `none`.
 - **Formatter: Line break**: The formatter will restrict line length as 80 characters in default. Toggle the following option will disable this feature.
 
     ![alt text](assets/screenshot-formatter-linebreak.png)

--- a/package.json
+++ b/package.json
@@ -463,6 +463,29 @@
           "scope": "machine",
           "markdownDescription": "%configuration.pdfViewer.themes.markdownDescription%"
         },
+        "overleaf-workshop.pdfViewer.defaultScrollMode": {
+          "type": "string",
+          "enum": [
+            "vertical",
+            "horizontal",
+            "wrapped",
+            "page"
+          ],
+          "default": "vertical",
+          "scope": "machine",
+          "markdownDescription": "%configuration.pdfViewer.defaultScrollMode.markdownDescription%"
+        },
+        "overleaf-workshop.pdfViewer.defaultSpreadMode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "odd",
+            "even"
+          ],
+          "default": "none",
+          "scope": "machine",
+          "markdownDescription": "%configuration.pdfViewer.defaultSpreadMode.markdownDescription%"
+        },
         "overleaf-workshop.invisibleMode.historyRefreshInterval": {
           "type": "number",
           "default": 3,

--- a/package.nls.json
+++ b/package.nls.json
@@ -55,6 +55,8 @@
     "configuration.pdfViewer.themes.theme.description": "The name of the theme.",
     "configuration.pdfViewer.themes.fontColor.description": "The font color of the theme.",
     "configuration.pdfViewer.themes.backgroundColor.description": "The background color of the theme.",
+    "configuration.pdfViewer.defaultScrollMode.markdownDescription": "Configure the default scroll mode used by the PDF viewer for new state. Existing saved viewer state takes precedence.",
+    "configuration.pdfViewer.defaultSpreadMode.markdownDescription": "Configure the default spread mode used by the PDF viewer for new state. Existing saved viewer state takes precedence.",
     "configuration.invisibleMode.historyRefreshInterval.markdownDescription": "The interval (in seconds) to refresh the project history in invisible mode, which is used to update the file changes, collaborator status, etc.",
     "configuration.invisibleMode.chatMessageRefreshInterval.markdownDescription": "The interval (in seconds) to refresh the chat messages in invisible mode.",
     "configuration.invisibleMode.inactiveTimeout.markdownDescription": "The timeout (in seconds) to mark a online Collaborator as inactivate in invisible mode.",

--- a/src/core/pdfViewEditorProvider.ts
+++ b/src/core/pdfViewEditorProvider.ts
@@ -92,8 +92,13 @@ export class PdfViewEditorProvider implements vscode.CustomEditorProvider<PdfDoc
                     break;
                 case 'ready':
                     const state = GlobalStateManager.getPdfViewPersist(this.context, doc.uri.toString());
-                    const colorThemes = vscode.workspace.getConfiguration('overleaf-workshop.pdfViewer').get('themes', undefined);
-                    webviewPanel.webview.postMessage({type:'initState', content:state, colorThemes});
+                    const config = vscode.workspace.getConfiguration('overleaf-workshop.pdfViewer');
+                    const colorThemes = config.get('themes', undefined);
+                    const defaults = {
+                        scrollMode: config.get('defaultScrollMode', 'vertical'),
+                        spreadMode: config.get('defaultSpreadMode', 'none'),
+                    };
+                    webviewPanel.webview.postMessage({type:'initState', content:state, colorThemes, defaults});
                     updateWebview();
                     break;
                 default:

--- a/views/pdf-viewer/index.js
+++ b/views/pdf-viewer/index.js
@@ -7,6 +7,17 @@
     const SpreadMode = { UNKNOWN:-1, NONE:0, ODD:1, EVEN:2 };
     const ScrollMode = { UNKNOWN:-1, VERTICAL:0, HORIZONTAL:1, WRAPPED:2, PAGE:3 };
     const SidebarView = { UNKNOWN:-1, NONE:0, THUMBS:1, OUTLINE:2, ATTACHMENTS:3, LAYERS:4 };
+    const ScrollModeMap = {
+        vertical: ScrollMode.VERTICAL,
+        horizontal: ScrollMode.HORIZONTAL,
+        wrapped: ScrollMode.WRAPPED,
+        page: ScrollMode.PAGE,
+    };
+    const SpreadModeMap = {
+        none: SpreadMode.NONE,
+        odd: SpreadMode.ODD,
+        even: SpreadMode.EVEN,
+    };
     let ColorThemes = {
         'default': {fontColor:'black', bgColor:'white'},
         'light': {fontColor:'black', bgColor:'#F5F5DC'},
@@ -88,6 +99,24 @@
             `;
         }
         document.head.appendChild(style);
+    }
+
+    function updatePdfViewerDefaults(defaults) {
+        if (defaults === undefined || defaults === null) {
+            return;
+        }
+        if (typeof defaults.scrollMode === 'string') {
+            const scrollMode = ScrollModeMap[defaults.scrollMode.toLowerCase()];
+            if (scrollMode !== undefined) {
+                globalPdfViewerState.pdfViewerScrollMode = scrollMode;
+            }
+        }
+        if (typeof defaults.spreadMode === 'string') {
+            const spreadMode = SpreadModeMap[defaults.spreadMode.toLowerCase()];
+            if (spreadMode !== undefined) {
+                globalPdfViewerState.pdfViewerSpreadMode = spreadMode;
+            }
+        }
     }
 
     function enableThemeToggleButton(initIndex = 0){
@@ -209,6 +238,7 @@
                     syncCode(message.content);
                     break;
                 case 'initState':
+                    updatePdfViewerDefaults(message.defaults);
                     if (message.content!==undefined) {
                         Object.assign(globalPdfViewerState, message.content);
                     }


### PR DESCRIPTION
> Closes #346 

Implemented the feature from upstream issue #346 with safe handling of the existing theme configuration flow.

**What Changed**
1. Added two new user settings:
- package.json: overleaf-workshop.pdfViewer.defaultScrollMode with values vertical, horizontal, wrapped, page
- package.json: overleaf-workshop.pdfViewer.defaultSpreadMode with values none, odd, even

2. Added localization text for the new settings:
- package.nls.json

3. Wired settings into the PDF viewer initialization message:
- pdfViewEditorProvider.ts
- Existing color themes payload is still sent exactly as before, now alongside defaults.

4. Applied defaults in webview state init without breaking saved-state behavior:
- index.js: added default mode mapping/apply logic
- index.js: defaults are applied first, then persisted state is merged on top

5. Documented the new options:
- wiki.md

**Behavior After Change**
- If a PDF has saved viewer state, that saved state still wins.
- If no saved state exists, the viewer now starts with configured default scroll/spread mode.
- This covers persistence across recompiles/reopen while allowing user-defined defaults for new state.
