### PR TITLE
fix: send rootResourcePath instead of rootDoc_id in compile request

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -589,14 +589,14 @@ export class BaseAPI {
                             {folder_id:newParentFolderId}, undefined, {'X-Csrf-Token': identity.csrfToken});
     }
 
-    async compile(identity:Identity, projectId:string, rootDoc_id:string|null,
+    async compile(identity:Identity, projectId:string, rootResourcePath:string|null,
         draft:boolean=false, stopOnFirstError:boolean=false
     ) {
         const body = {
             check: 'silent',
             draft,
             incrementalCompilesEnabled: true,
-            rootDoc_id,
+            rootResourcePath,   // file path e.g. "main.tex"
             stopOnFirstError
         };
 

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -885,9 +885,15 @@ export class VirtualFileSystem extends vscode.Disposable {
             }
             // compile project
             const resolvedRootDocId = rootDocId ?? this.root?.rootDoc_id ?? null;
-            const rootResourcePath = resolvedRootDocId
-                ? (this._resolveById(resolvedRootDocId)?.path ?? '').replace(/^\//, '')
-                : null;
+            let rootResourcePath: string | null = null;
+            if (resolvedRootDocId) {
+                const rootEntry = this._resolveById(resolvedRootDocId);
+                if (rootEntry?.path) {
+                    rootResourcePath = rootEntry.path.replace(/^\//, '');
+                } else {
+                    console.warn(`Unable to resolve root document id '${resolvedRootDocId}' to a path; compiling without explicit rootResourcePath.`);
+                }
+            }
             const res = await this.api.compile(identity, this.projectId, rootResourcePath, draft, stopOnFirstError);
             if (res.type==='success' && res.compile?.status==='success') {
                 this.updateOutputs(res.compile.outputFiles);

--- a/src/core/remoteFileSystemProvider.ts
+++ b/src/core/remoteFileSystemProvider.ts
@@ -884,7 +884,11 @@ export class VirtualFileSystem extends vscode.Disposable {
                 await this.api.deleteAuxFiles(identity, this.projectId);
             }
             // compile project
-            const res = await this.api.compile(identity, this.projectId, rootDocId??this.root?.rootDoc_id??null, draft, stopOnFirstError);
+            const resolvedRootDocId = rootDocId ?? this.root?.rootDoc_id ?? null;
+            const rootResourcePath = resolvedRootDocId
+                ? (this._resolveById(resolvedRootDocId)?.path ?? '').replace(/^\//, '')
+                : null;
+            const res = await this.api.compile(identity, this.projectId, rootResourcePath, draft, stopOnFirstError);
             if (res.type==='success' && res.compile?.status==='success') {
                 this.updateOutputs(res.compile.outputFiles);
                 return true;


### PR DESCRIPTION
Fixes #355 

# Fix: Compile failure — `rootResourcePath is missing in request body`

## Problem

Every time a save is performed, it triggers a compile request that fails with a `400` error from Overleaf's API:

```
Compile failure. 400: {"error":"rootResourcePath is missing in request body"}
```

This causes a permanent red flag in the VS Code status bar and no PDF output in `.output`, even though the project compiles successfully on overleaf.com directly.

## Root Cause

Overleaf's compile API expects a `rootResourcePath` field containing the **file path** of the root document (e.g. `"main.tex"`). However, the extension was sending `rootDoc_id` — a **MongoDB document ID** (e.g. `"69c4fd3d5256760243b6e292"`) — which is a completely different field that the API does not accept as a substitute for `rootResourcePath`.

The bug has two parts:

1. **`src/api/base.ts`** — The compile request body included `rootDoc_id` but never included `rootResourcePath`.

2. **`src/core/remoteFileSystemProvider.ts`** — The `compile()` method passed the raw MongoDB ID directly to the API without resolving it to a file path first.

The ID was available and correct (confirmed via debugging) — it just needed to be resolved to a path using the existing `_resolveById()` method before being sent.

## Fix

**`src/api/base.ts`** — Add `rootResourcePath` to the compile request body (the parameter is renamed accordingly):

```typescript
async compile(identity, projectId, rootResourcePath, draft = false, stopOnFirstError = false) {
    const body = {
        check: 'silent',
        draft,
        incrementalCompilesEnabled: true,
        rootResourcePath,   // file path e.g. "main.tex"
        stopOnFirstError
    };
    ...
}
```

**`src/core/remoteFileSystemProvider.ts`** — Resolve the MongoDB ID to a file path before calling the API:

```typescript
// compile project
const resolvedRootDocId = rootDocId ?? this.root?.rootDoc_id ?? null;
const rootResourcePath = resolvedRootDocId
    ? (this._resolveById(resolvedRootDocId)?.path ?? '').replace(/^\//, '')
    : null;
const res = await this.api.compile(identity, this.projectId, rootResourcePath, draft, stopOnFirstError);
```

The `.replace(/^\//, '')` strips the leading `/` from the path returned by `_resolveById()`, giving a clean relative path like `main.tex` rather than `/main.tex`.

## Testing

Verified locally on:
- **Overleaf Workshop**: `0.15.7`
- **VS Code**: `1.113.0` (x64, `.deb` install on Ubuntu Linux)
- **Overleaf**: `www.overleaf.com` (official server)

After the fix, saving a `.tex` file triggers a successful compile, the PDF appears in `.output`, and the red flag is gone.

## Notes

- The `rootDoc_id` field in the request body has been removed since it was never a valid field for Overleaf's compile API — only `rootResourcePath` is required.
- This fix does not change any other behaviour; if `rootResourcePath` resolves to `null` (no root doc set), the compile request omits it, which matches the previous behaviour.